### PR TITLE
fix: set csrf origin to allow login

### DIFF
--- a/tango/settings.py
+++ b/tango/settings.py
@@ -33,6 +33,7 @@ SECRET_KEY = os.environ.get(
 )
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost").split(",")
+CSRF_TRUSTED_ORIGINS = ["https://tango.elixir-hpc.si"]
 
 # Application definition
 


### PR DESCRIPTION
The commit isn't mine, but I don't know whose it is. I saw it uncommitted on the live machine so I presume this was the fix that made the login finally work.