### PR TITLE
fix: add new domain as trusted origin

### DIFF
--- a/tmd/settings.py
+++ b/tmd/settings.py
@@ -33,7 +33,7 @@ SECRET_KEY = os.environ.get(
 )
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "localhost").split(",")
-CSRF_TRUSTED_ORIGINS = ["https://tango.elixir-hpc.si"]
+CSRF_TRUSTED_ORIGINS = ["https://tango.elixir-hpc.si", "https://tmd.elixir-europe.org"]
 
 # Application definition
 


### PR DESCRIPTION
This PR resolve #32 by adding the new domain to the trusted origin list.