### PR TITLE
Feat/add user accessible data import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ db.sqlite3
 
 .DS_Store
 
+test-data

--- a/dash_app/templates/dash_app/confirm.html
+++ b/dash_app/templates/dash_app/confirm.html
@@ -1,0 +1,16 @@
+{% extends "common/base.html" %}
+{% load plotly_dash %}
+{% block header %}
+    {% plotly_header %}
+{% endblock %}
+{% block content %}
+    <h1>{{ title }}</h1>
+    <div class="mb-3 row">
+        <form method="post">{% csrf_token %}
+            <p>{{ message }}</p>
+            {{ form }}
+            <a href="{{abort_url}}" class="btn btn-primary">Abort</a>
+            <input type="submit" class="btn btn-danger" value="Confirm">
+        </form>
+    </div>
+{% endblock %}

--- a/dash_app/templates/dash_app/data-warning.html
+++ b/dash_app/templates/dash_app/data-warning.html
@@ -1,0 +1,4 @@
+<div class="alert alert-danger alert-dismissible fade show" role="alert">
+    <h4>Warning: Experimental functionality</h4>
+    <p>Please note that this functionality is experimental and we can't guarantee that the data will be saved. Make sure to keep a local backup of all uploaded data until further notice.</p>
+</div>

--- a/dash_app/templates/dash_app/model-form.html
+++ b/dash_app/templates/dash_app/model-form.html
@@ -6,6 +6,7 @@
 {% block content %}
     <h1>{{title}}</h1>
     {% include 'common/tabs.html' %}
+    {% include 'dash_app/data-warning.html' %}
     <h2>Stats</h2>
     <div class="mb-3 row">
         <table class="table table-bordered">

--- a/dash_app/templates/dash_app/model-form.html
+++ b/dash_app/templates/dash_app/model-form.html
@@ -24,7 +24,8 @@
             </tbody>
         </table>
     </div>
-    <h2>Edit</h2>
+    {% if form.fields or actions %}
+    {% if form.fields %}<h2>Edit</h2>{% endif %}
     <div class="mb-3 row">
         {{form.errors}}
         <form method="POST" enctype="multipart/form-data">
@@ -38,9 +39,10 @@
             </div>
             {%endfor%}
             <hr />
-            <button type="submit" class="btn btn-success">Update</button>
+            {% if form.fields %}<button type="submit" class="btn btn-success">Update</button>{% endif %}
             {% for href, label in actions %}
             <a href="{{href}}" class="btn btn-danger">{{label}}</a>{% endfor %}
         </form>
     </div>
+    {% endif %}
 {% endblock %}

--- a/dash_app/templates/dash_app/model-form.html
+++ b/dash_app/templates/dash_app/model-form.html
@@ -39,7 +39,7 @@
             </div>
             {%endfor%}
             <hr />
-            {% if form.fields %}<button type="submit" class="btn btn-success">Update</button>{% endif %}
+            {% if form.fields and can_edit %}<button type="submit" class="btn btn-success">Update</button>{% endif %}
             {% for href, label in actions %}
             <a href="{{href}}" class="btn btn-danger">{{label}}</a>{% endfor %}
         </form>

--- a/dash_app/templates/dash_app/model-form.html
+++ b/dash_app/templates/dash_app/model-form.html
@@ -1,0 +1,46 @@
+{% extends "common/base.html" %}
+{% load plotly_dash %}
+{% block header %}
+    {% plotly_header %}
+{% endblock %}
+{% block content %}
+    <h1>{{title}}</h1>
+    {% include 'common/tabs.html' %}
+    <h2>Stats</h2>
+    <div class="mb-3 row">
+        <table class="table table-bordered">
+            <thead class="thead-light">
+                <tr>
+                    <th>Name</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, value in stats %}
+                <tr>
+                    <td>{{ name }}</td>
+                    <td>{{ value }}</td>
+                </tr>{% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <h2>Edit</h2>
+    <div class="mb-3 row">
+        {{form.errors}}
+        <form method="POST" enctype="multipart/form-data">
+            {% csrf_token %}
+            {% for field in form %}
+            <div class="mb-3 row">
+                <label for="{{field.html_name}}" class="col-sm-2 col-form-label">{{field.label}}</label>
+                <div class="col-sm-10">
+                    {{field}}
+                </div>
+            </div>
+            {%endfor%}
+            <hr />
+            <button type="submit" class="btn btn-success">Update</button>
+            {% for href, label in actions %}
+            <a href="{{href}}" class="btn btn-danger">{{label}}</a>{% endfor %}
+        </form>
+    </div>
+{% endblock %}

--- a/dash_app/templates/dash_app/model-list.html
+++ b/dash_app/templates/dash_app/model-list.html
@@ -1,0 +1,42 @@
+{% extends "common/base.html" %}
+{% load plotly_dash %}
+{% block header %}
+    {% plotly_header %}
+{% endblock %}
+{% block content %}
+    <h1>{{title}}</h1>
+    {% include 'common/tabs.html' %}
+    <div class="mb-3 row">
+        <nav aria-label="Page navigation">
+            <ul class="pagination">
+                <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+                <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Next</a></li>
+                <li class="page-item">{% if node_only %}<a class="page-link active" href="?page_size={{ page_size }}">Node only</a>{% else %}<a class="page-link" href="?node_only&page_size={{ page_size }}">Node only</a>{% endif %}</li>
+                <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
+            </ul>
+        </nav>
+        <table class="table table-bordered">
+            <thead class="thead-light">
+                <tr>
+                    {% for heading in table_headings %}
+                    <th>{{heading}}</th>{% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in table_items %}
+                <tr>
+                    {% for value, href in item %}
+                    <td>{% if href %}<a href="{{href}}">{{value}}</a>{% else %}{{value}}{% endif %}</td>{% endfor %}
+                </tr>{% endfor %}
+            </tbody>
+        </table>
+        <nav aria-label="Page navigation">
+            <ul class="pagination">
+                <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+                <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Next</a></li>
+                <li class="page-item">{% if node_only %}<a class="page-link active" href="?page_size={{ page_size }}">Node only</a>{% else %}<a class="page-link" href="?node_only&page_size={{ page_size }}">Node only</a>{% endif %}</li>
+                <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
+            </ul>
+        </nav>
+    </div>
+{% endblock %}

--- a/dash_app/templates/dash_app/model-list.html
+++ b/dash_app/templates/dash_app/model-list.html
@@ -6,6 +6,7 @@
 {% block content %}
     <h1>{{title}}</h1>
     {% include 'common/tabs.html' %}
+    {% include 'dash_app/data-warning.html' %}
     <div class="mb-3 row">
         <nav aria-label="Page navigation">
             <ul class="pagination">

--- a/dash_app/templates/dash_app/upload.html
+++ b/dash_app/templates/dash_app/upload.html
@@ -1,0 +1,68 @@
+{% extends "common/base.html" %}
+{% load plotly_dash %}
+{% block header %}
+    {% plotly_header %}
+{% endblock %}
+{% block content %}
+    <h1>{{ title }}</h1>
+    {% include 'common/tabs.html' %}
+    {% for form in forms %}
+    <h2>{{form.title}}</h2>
+    {% if form.description %}{% for paragraph in form.description %}<p>{{ paragraph }}</p>{%endfor%}{% endif %}
+    {% if form.non_field_errors %}{% for error in form.non_field_errors %}
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        {{error}}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}{% endif %}
+    <div class="mb-3 row">
+        <form method="POST" enctype="multipart/form-data">
+            {% csrf_token %}
+            {% for field in form %}
+            {% if not field.field.disabled %}
+            <div class="mb-3 row">
+                <label for="{{field.html_name}}" class="col-sm-2 col-form-label">{{field.label}}</label>
+                <div class="col-sm-10">
+                    {{field}}
+                </div>
+            </div>
+            {% else %}
+            {{field}}
+            {% endif %}
+            {%endfor%}
+            <button type="submit" class="btn btn-success">Upload</button>
+        </form>
+    </div>
+    <div class="mb-3 row">
+        {% if form.outputs.table %}
+        {% with table=form.outputs.table %}
+        <div class="panel panel-primary">
+            <div class="panel-body">
+                <table class="table table-bordered">
+                    <thead class="thead-light">
+                        <tr>
+                            {% for header in table.headers %}<th>{{header}}</th>{% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table.content %}
+                        <tr>
+                            {% for column in row %}<td>{{column}}</td>{% endfor %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {%endwith%}
+        {% endif %}
+        {% if form.outputs.summary %}
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{form.outputs.summary}}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endif %}
+        <hr/>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/dash_app/templates/dash_app/upload.html
+++ b/dash_app/templates/dash_app/upload.html
@@ -6,6 +6,7 @@
 {% block content %}
     <h1>{{ title }}</h1>
     {% include 'common/tabs.html' %}
+    {% include 'dash_app/data-warning.html' %}
     {% for form in forms %}
     <h2>{{form.title}}</h2>
     {% if form.description %}{% for paragraph in form.description %}<p>{{ paragraph }}</p>{%endfor%}{% endif %}

--- a/dash_app/urls.py
+++ b/dash_app/urls.py
@@ -6,6 +6,14 @@ from .views.demographic import demographic_report
 from .views.impact import impact_report
 from .views.quality import quality_report
 from .views.worldmap import world_map
+from .views.upload import upload_data
+from .views.model_views import (
+    EventView,
+    EventListView,
+    QualityMetricsDeleteView,
+    DemographicMetricsDeleteView,
+    ImpactMetricsDeleteView
+)
 
 
 urlpatterns = [
@@ -15,4 +23,10 @@ urlpatterns = [
     path('demographic', demographic_report, name='demographic-report'),
     path('impact', impact_report, name='impact-report'),
     path('world-map', world_map, name='world-map'),
+    path('upload-data', upload_data, name='upload-data'),
+    path('event/<int:pk>', EventView.as_view(), name='event-edit'),
+    path('event/list', EventListView.as_view(), name='event-list'),
+    path('event/delete-metrics/demographic/<int:pk>', DemographicMetricsDeleteView.as_view(), name="demographic-delete-metrics"),
+    path('event/delete-metrics/impact/<int:pk>', ImpactMetricsDeleteView.as_view(), name="impact-delete-metrics"),
+    path('event/delete-metrics/quality/<int:pk>', QualityMetricsDeleteView.as_view(), name="quality-delete-metrics")
 ]

--- a/dash_app/urls.py
+++ b/dash_app/urls.py
@@ -9,10 +9,12 @@ from .views.worldmap import world_map
 from .views.upload import upload_data
 from .views.model_views import (
     EventView,
+    InstitutionView,
     EventListView,
+    InstitutionListView,
     QualityMetricsDeleteView,
     DemographicMetricsDeleteView,
-    ImpactMetricsDeleteView
+    ImpactMetricsDeleteView,
 )
 
 
@@ -25,7 +27,9 @@ urlpatterns = [
     path('world-map', world_map, name='world-map'),
     path('upload-data', upload_data, name='upload-data'),
     path('event/<int:pk>', EventView.as_view(), name='event-edit'),
+    path('institution/<int:pk>', InstitutionView.as_view(), name='institution-edit'),
     path('event/list', EventListView.as_view(), name='event-list'),
+    path('institution/list', InstitutionListView.as_view(), name='institution-list'),
     path('event/delete-metrics/demographic/<int:pk>', DemographicMetricsDeleteView.as_view(), name="demographic-delete-metrics"),
     path('event/delete-metrics/impact/<int:pk>', ImpactMetricsDeleteView.as_view(), name="impact-delete-metrics"),
     path('event/delete-metrics/quality/<int:pk>', QualityMetricsDeleteView.as_view(), name="quality-delete-metrics")

--- a/dash_app/views/common.py
+++ b/dash_app/views/common.py
@@ -13,6 +13,14 @@ from django.urls import reverse
 
 def get_tabs(request):
     view_name = request.resolver_match.view_name
+    user_input = (
+        [
+            ("Upload data", "upload-data"),
+            ("Edit events", "event-list")
+        ]
+        if request.user.is_authenticated
+        else []
+    )
     return {
         "tabs": [
             {"title": title, "url": reverse(name), "active": view_name == name}
@@ -22,7 +30,8 @@ def get_tabs(request):
                 ("Quality metrics", "quality-report"),
                 ("Demographics metrics", "demographic-report"),
                 ("Impact metrics", "impact-report"),
-                ("All events", "all-events")
+                ("All events", "all-events"),
+                *user_input,
             ]
         ]
     }

--- a/dash_app/views/common.py
+++ b/dash_app/views/common.py
@@ -16,7 +16,8 @@ def get_tabs(request):
     user_input = (
         [
             ("Upload data", "upload-data"),
-            ("Edit events", "event-list")
+            ("Edit events", "event-list"),
+            ("Edit institutions", "institution-list")
         ]
         if request.user.is_authenticated
         else []

--- a/dash_app/views/model_views.py
+++ b/dash_app/views/model_views.py
@@ -90,15 +90,27 @@ class EventView(LoginRequiredMixin, UserHasNodeMixin, GenericUpdateView):
 
 class InstitutionView(LoginRequiredMixin, GenericUpdateView):
     model = models.OrganisingInstitution
-    fields = [
-        "name",
-        "country"
-    ]
+    fields = []
     
     def get_stats(self):
-        return [
-            ("Events", models.Event.objects.filter(organising_institution=self.object).count())
+        stat_fields = [
+            "name",
+            "country",
         ]
+        field_stats = [
+            (field, getattr(self.object, field))
+            for field in stat_fields
+        ]
+        return [
+            *field_stats,
+            ("Events", models.Event.objects.filter(organising_institution=self.object).count()),
+        ]
+    
+    def get_actions(self):
+        return [
+            ("", "Update info"),
+        ]
+        
 
 
 class GenericListView(ListView):

--- a/dash_app/views/model_views.py
+++ b/dash_app/views/model_views.py
@@ -1,0 +1,236 @@
+from django.views.generic.edit import FormView, UpdateView, DeleteView
+from django.views.generic.list import ListView
+from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from metrics import forms
+from metrics import models
+from django.core import serializers
+from collections.abc import Iterable
+from .common import get_tabs
+from django.urls import reverse_lazy, reverse
+
+
+class GenericUpdateView(UpdateView):
+    template_name = "dash_app/model-form.html"
+    model = models.Quality
+
+    def get_actions(self):
+        return []
+    
+    def get_stats(self):
+        return None
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = self.title
+        for field in context["form"]:
+            field.field.widget.attrs.update({
+                "class": "form-control",
+            })
+        context["actions"] = self.get_actions()
+        context["stats"] = self.get_stats()
+        context.update(get_tabs(self.request))
+        return context
+
+
+class UserHasNodeMixin(UserPassesTestMixin):
+    def test_func(self):
+        try:
+            model_object = self.get_object()
+            return self.request.user.get_node() == model_object.node_main
+        except self.model.DoesNotExist:
+            return True
+
+
+class EventView(LoginRequiredMixin, UserHasNodeMixin, GenericUpdateView):
+    model = models.Event
+    fields = [
+        "user",
+        "code",
+        "title",
+        "node",
+        "node_main",
+        "date_start",
+        "date_end",
+        "duration",
+        "type",
+        "organising_institution",
+        "location_city",
+        "location_country",
+        "funding",
+        "target_audience",
+        "additional_platforms",
+        "communities",
+        "number_participants",
+        "number_trainers",
+        "url",
+        "status",
+    ]
+
+    @property
+    def title(self):
+        return f"Event: {self.object}"
+    
+    def get_actions(self):
+        return [
+            (reverse("quality-delete-metrics", kwargs={"pk": self.object.id}), "Delete quality metrics"),
+            (reverse("impact-delete-metrics", kwargs={"pk": self.object.id}), "Delete impact metrics"),
+            (reverse("demographic-delete-metrics", kwargs={"pk": self.object.id}), "Delete demographic metrics"),
+        ]
+    
+    def get_stats(self):
+        return [
+            (name, model.objects.filter(event=self.object).count())
+            for name, model in [
+                ("Quality metrics", models.Quality),
+                ("Impact metrics", models.Impact),
+                ("Demographic metrics", models.Demographic)
+            ]
+        ]
+
+
+class GenericListView(ListView):
+    template_name = "dash_app/model-list.html"
+    paginate_by = 10
+    max_paginate_by = 50
+    min_paginate_by = 10
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = self.title
+        extras_list = [
+            self.get_entry_extras(entry)
+            for entry in context["object_list"]
+        ]
+        max_extras = max(len(e) for e in extras_list)
+        context["table_headings"] = [
+            *["" for _i in range(max_extras)],
+            *self.fields
+        ]
+        context["table_items"] = [
+            [
+                *extras,
+                *[
+                    (
+                        self.parse_value(value),
+                        value.get_absolute_url() if hasattr(value, "get_absolute_url") else None
+                    )
+                    for value in self.get_values(entry)
+                ]
+            ]
+            for extras, entry in zip(extras_list, context["object_list"])
+        ]
+        context["node_only"] = self.node_only
+        context["page_size"] = self.get_paginate_by(None)
+        context.update(get_tabs(self.request))
+        return context
+
+    @property
+    def node_only(self):
+        return "node_only" in self.request.GET
+
+    def get_entry_extras(self, entry):
+        return []
+
+    def get_paginate_by(self, queryset):
+        try:
+            requested_paginate_by = int(self.request.GET.get("page_size", self.paginate_by))
+            return max(
+                min(self.max_paginate_by, requested_paginate_by),
+                self.min_paginate_by
+            )
+        except ValueError:
+            return self.paginate_by
+
+    def get_values(self, entry):
+        return [getattr(entry, fieldname) for fieldname in self.fields]
+
+    def parse_value(self, value):
+        value_list = (
+            list(value.all())
+            if hasattr(value, "all")
+            else (
+                value
+                if type(value) in [list, tuple]
+                else [value]
+            )
+        )
+        return ", ".join([str(v) for v in value_list])
+
+
+class EventListView(LoginRequiredMixin, GenericListView):
+    model = models.Event
+    paginate_by = 30
+    fields = [
+        "code",
+        "id",
+        "title",
+        "node",
+        "node_main",
+        "date_period",
+        "type",
+        "organising_institution",
+    ]
+    title = "Event list"
+
+    def get_queryset(self):
+        queryset = super().get_queryset().order_by("-id")
+        return (
+            queryset.filter(node=self.request.user.get_node())
+            if self.node_only
+            else queryset
+        )
+
+    def get_entry_extras(self, entry):
+        user_node = self.request.user.get_node()
+        can_edit = user_node == entry.node_main
+        return [
+            ("View", entry.get_absolute_url()) if can_edit else ("", None),
+        ]
+
+
+class GenericEventMetricsDeleteView(DeleteView):
+    template_name = "dash_app/confirm.html"
+    model = models.Event
+    success_url = reverse_lazy("event-list")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        name = self.metrics_model.__name__
+        context["title"] = f"Delete {name} metrics for: {self.object}"
+        context["abort_url"] = self.success_url
+        context["message"] = f"Do you want to delete {name} metrics for the event '{self.object}'?"
+        return context
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
+    def form_valid(self, form):
+        success_url = self.get_success_url()
+        self.metrics_model.objects.filter(event=self.object).delete()
+        return HttpResponseRedirect(success_url)
+
+
+class QualityMetricsDeleteView(
+    LoginRequiredMixin,
+    UserHasNodeMixin,
+    GenericEventMetricsDeleteView
+):
+    metrics_model = models.Quality
+
+
+class ImpactMetricsDeleteView(
+    LoginRequiredMixin,
+    UserHasNodeMixin,
+    GenericEventMetricsDeleteView
+):
+    metrics_model = models.Impact
+
+
+class DemographicMetricsDeleteView(
+    LoginRequiredMixin,
+    UserHasNodeMixin,
+    GenericEventMetricsDeleteView
+):
+    metrics_model = models.Demographic

--- a/dash_app/views/model_views.py
+++ b/dash_app/views/model_views.py
@@ -65,7 +65,6 @@ class EventView(LoginRequiredMixin, GenericUpdateView):
     model = models.Event
     fields = [
         "user",
-        "code",
         "title",
         "node",
         "node_main",
@@ -108,7 +107,17 @@ class EventView(LoginRequiredMixin, GenericUpdateView):
         )
     
     def get_stats(self):
-        return self.object.stats
+        stat_fields = [
+            "code",
+        ]
+        field_stats = [
+            (field, getattr(self.object, field))
+            for field in stat_fields
+        ]
+        return [
+            *self.object.stats,
+            *field_stats
+        ]
 
 
 class InstitutionView(LoginRequiredMixin, GenericUpdateView):
@@ -230,7 +239,7 @@ class EventListView(LoginRequiredMixin, GenericListView):
     def get_queryset(self):
         queryset = super().get_queryset().order_by("-id")
         return (
-            queryset.filter(node=self.request.user.get_node())
+            queryset.filter(node_main=self.request.user.get_node())
             if self.node_only
             else queryset
         )

--- a/dash_app/views/model_views.py
+++ b/dash_app/views/model_views.py
@@ -132,14 +132,8 @@ class InstitutionView(LoginRequiredMixin, GenericUpdateView):
 
     def form_valid(self, form):
         result = super().form_valid(form)
-        
-        ror_id_base = re.match("^https://ror.org/(.+)$", self.object.ror_id)[1]
-        response = requests.get(f"https://api.ror.org/organizations/{ror_id_base}", allow_redirects=True)
-        if response.status_code == 200:
-            data = response.json()
-            self.object.name = data["name"]
-            self.object.country = data.get("country", {}).get("country_name", "")
-            self.object.save()
+        self.object.update_ror_data()
+        self.object.save()
         
         return result
 

--- a/dash_app/views/upload.py
+++ b/dash_app/views/upload.py
@@ -1,0 +1,172 @@
+from django.shortcuts import render
+from .common import get_tabs
+from django import forms
+from django.forms.widgets import FileInput, Select, CheckboxInput
+import re
+import csv
+import io
+from metrics import import_utils, models
+import traceback
+from django.core.exceptions import ValidationError
+from django.db import transaction
+import datetime
+from django.contrib.auth.decorators import login_required
+
+
+UPLOAD_TYPES = {
+    upload_type["id"]: upload_type
+    for upload_type in [
+        {
+            "id": "events",
+            "title": "Events",
+            "description": ""
+        },
+        {
+            "id": "demographic_quality_metrics",
+            "title": "Demographic and quality metrics",
+            "description": ""
+        },
+        {
+            "id": "impact_metrics",
+            "title": "Impact metrics",
+            "description": ""
+        },
+    ]
+}
+
+
+class DataUploadForm(forms.Form):
+    file = forms.FileField(
+        label="CSV batch file",
+        widget=FileInput(attrs={"class": "form-control"}),
+    )
+    upload_type = forms.ChoiceField(
+        label="Data type",
+        choices=(
+            (upload_id, upload_type["title"])
+            for (upload_id, upload_type) in UPLOAD_TYPES.items()
+        ),
+        widget=Select(attrs={"class": "form-control d-none"}),
+    )
+
+    def __init__(self, *args, title=None, description=None, fixed_type=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fixed_type = fixed_type
+        if self.fixed_type is not None:
+            upload_type = self.fields["upload_type"]
+            upload_type.initial = self.fixed_type
+            upload_type.disabled = True
+
+        self.description = (
+            None
+            if description is None
+            else re.split("\n\n+", description)
+        )
+        self.title = title
+
+
+def summary_output(items: list):
+    return f"Successfully uploaded {len(items)} objects."
+
+
+def table_output(columns: dict):
+    def _table_output(items: list):
+        return {
+            "headers": [value for value in columns.values()],
+            "content": [
+                [getattr(item, key, None) for key in columns.keys()]
+                for item in items
+            ]
+        }
+    return _table_output
+
+@login_required
+def upload_data(request):
+    forms = [
+        DataUploadForm(
+            request.POST if request.method == "POST" else None,
+            request.FILES if request.method == "POST" else None,
+            fixed_type=upload_type["id"],
+            title=upload_type["title"],
+            description=upload_type["description"],
+            prefix=upload_type["id"],
+        )
+        for upload_type in UPLOAD_TYPES.values()
+    ]
+
+    if request.method == "POST":
+        for form in forms:
+            if form.has_changed() and form.is_valid():
+                data = form.cleaned_data
+                upload_type = data["upload_type"]
+                file = data["file"]
+
+                node_main = request.user.get_node()
+                current_time = datetime.datetime.now()
+                import_context = import_utils.LegacyImportContext(
+                    user=request.user,
+                    node_main=node_main,
+                    timestamps=(
+                        current_time,
+                        current_time
+                    ),
+                )
+
+                (parser, importer, view_transforms) = {
+                    "events": (
+                        import_utils.legacy_to_current_event_dict,
+                        import_context.event_from_dict,
+                        {
+                            "summary": summary_output,
+                            "table": table_output({
+                                "id": "Event Code",
+                                "title": "Title",
+                                "date_start": "Start date",
+                                "date_end": "End date"
+                            })
+                        }
+                    ),
+                    "demographic_quality_metrics": (
+                        import_utils.legacy_to_current_quality_or_demographic_dict,
+                        import_context.quality_or_demographic_from_dict,
+                        {"summary": summary_output}
+                    ),
+                    "impact_metrics": (
+                        import_utils.legacy_to_current_impact_dict,
+                        import_context.impact_from_dict,
+                        {"summary": summary_output}
+                    ),
+                }[upload_type]
+
+                csv_stream = io.StringIO(file.read().decode())
+                reader = csv.DictReader(csv_stream, delimiter=',')
+                entries = []
+                for (index, row) in enumerate(reader):
+                    try:
+                        entries.append(parser(row))
+                    except ValidationError as e:
+                        traceback.print_exc()
+                        form.add_error(None, f"Failed to parse '{upload_type}' row {index} : {e}")
+
+                if len(form.errors) == 0:
+                    items = []
+                    try:
+                        with transaction.atomic():
+                            items = [importer(entry) for entry in entries]
+
+                        form.outputs = {
+                            key: view_transform(items)
+                            for key, view_transform in view_transforms.items()
+                        }
+                    except Exception as e:
+                        traceback.print_exc()
+                        form.add_error(None, f"Failed to import '{upload_type}': {e}")
+    return render(
+        request,
+        'dash_app/upload.html',
+        context={
+            "title": "Upload data",
+            **get_tabs(request),
+            "forms": forms,
+        }
+    )

--- a/metrics/import_utils.py
+++ b/metrics/import_utils.py
@@ -43,6 +43,7 @@ class ImportContext:
         ]
         event.node.add(*nodes)
 
+        event.full_clean()
         return event
 
     def demographic_from_dict(self, data: dict):
@@ -59,6 +60,7 @@ class ImportContext:
             gender=data['gender'],
             career_stage=data['career_stage'],
         )
+        demographic.full_clean()
         return demographic
 
     def quality_from_dict(self, data: dict):
@@ -76,6 +78,7 @@ class ImportContext:
             balance=data['balance'],
             email_contact=data['email_contact'],
         )
+        quality.full_clean()
         return quality
 
     def impact_from_dict(self, data: dict):
@@ -97,6 +100,7 @@ class ImportContext:
             people_share_knowledge=data['people_share_knowledge'],
             recommend_others=data['recommend_others'],
         )
+        impact.full_clean()
         return impact
     
     def get_user_and_event(self, data: dict):
@@ -160,7 +164,7 @@ class LegacyImportContext(ImportContext):
 
 
 def csv_to_array(csv_string):
-    return [x for x in csv_string.split(",")] if csv_string else []
+    return [x.strip() for x in csv_string.split(",")] if csv_string else []
 
 
 def convert_to_timestamp(date_string):

--- a/metrics/import_utils.py
+++ b/metrics/import_utils.py
@@ -1,0 +1,257 @@
+from datetime import datetime
+from metrics.models import Event, Demographic, Quality, Impact, User, Node
+from django.utils.text import slugify
+
+
+class ImportContext:
+    def __init__(self, user=None, node_main=None):
+        self._user = user
+        self._node_main = node_main
+
+    def event_from_dict(self, data: dict):
+        (created, modified) = timestamps_from_dict(data)
+
+        event = Event.objects.create(
+            user=self.user_from_data(data),
+            created=created,
+            modified=modified,
+            code=slugify(data['code']),
+            title=data['title'],
+            node_main=self.node_from_data(data),
+            date_start=convert_to_date(data['date_start']),
+            date_end=convert_to_date(data['date_end']),
+            duration=float(data['duration']),
+            type=data['type'],
+            funding=csv_to_array(data['funding']),
+            location_city=data['location_city'],
+            location_country=data['location_country'],
+            target_audience=csv_to_array(data['target_audience']),
+            additional_platforms=csv_to_array(data['additional_platforms']),
+            communities=csv_to_array(data['communities']),
+            number_participants=data['number_participants'],
+            number_trainers=data['number_trainers'],
+            url=data['url'],
+            status=data['status'],
+        )
+        # event.organising_institution.set([data['organising_institution']])
+        node_names = data['node'].split(",")
+        stripped_names = [name.strip() for name in node_names]
+        nodes = [
+            Node.objects.get(name=node)
+            for node in stripped_names
+        ]
+        event.node.add(*nodes)
+
+        return event
+
+    def demographic_from_dict(self, data: dict):
+        (created, modified) = timestamps_from_dict(data)
+        demographic = Demographic.objects.create(
+            user=self.user_from_data(data),
+            created=created,
+            modified=modified,
+            event=Event.objects.get(code=int(data['event'])),
+            heard_from=csv_to_array(data['heard_from']),
+            employment_sector=data['employment_sector'],
+            employment_country=data['employment_country'],
+            gender=data['gender'],
+            career_stage=data['career_stage'],
+        )
+        return demographic
+
+    def quality_from_dict(self, data: dict):
+        (created, modified) = timestamps_from_dict(data)
+        quality = Quality.objects.create(
+            user=self.user_from_data(data),
+            created=created,
+            modified=modified,
+            event=Event.objects.get(code=data['event']),
+            used_resources_before=data['used_resources_before'],
+            used_resources_future=data['used_resources_future'],
+            recommend_course=data['recommend_course'],
+            course_rating=data['course_rating'],
+            balance=data['balance'],
+            email_contact=data['email_contact'],
+        )
+        return quality
+
+    def impact_from_dict(self, data: dict):
+        (created, modified) = timestamps_from_dict(data)
+        impact = Impact.objects.create(
+            user=self.user_from_data(data),
+            created=created,
+            modified=modified,
+            event=Event.objects.get(code=data['event']),
+            when_attend_training=data['when_attend_training'],
+            main_attend_reason=data['main_attend_reason'],
+            how_often_use_before=data['how_often_use_before'],
+            how_often_use_after=data['how_often_use_after'],
+            able_to_explain=data['able_to_explain'],
+            able_use_now=data['able_use_now'],
+            help_work=csv_to_array(data['help_work']),
+            attending_led_to=csv_to_array(data['attending_led_to']),
+            people_share_knowledge=data['people_share_knowledge'],
+            recommend_others=data['recommend_others'],
+        )
+        return impact
+
+    def user_from_data(self, data: dict):
+        return (
+            User.objects.get(username=data['user'])
+            if self._user is None
+            else self._user
+        )
+
+    def node_from_data(self, data: dict):
+        node_main = data['node_main'] if data['node_main'] else ''
+        return (
+            Node.objects.get(
+                name=node_main
+            ) if node_main and self._node_main is None
+            else self._node_main
+        )
+
+    @staticmethod
+    def from_request(request):
+        return ImportContext(user=request.user)
+
+
+def csv_to_array(csv_string):
+    return [x for x in csv_string.split(",")] if csv_string else []
+
+
+def convert_to_timestamp(date_string):
+    return datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S').timestamp()
+
+
+def convert_to_date(date_string):
+    return datetime.strptime(date_string, '%Y-%m-%d').date()
+
+
+def timestamps_from_dict(data: dict):
+    created = (
+        convert_to_timestamp(data['created'])
+        if data['created']
+        else ''
+    )
+    modified = (
+        convert_to_timestamp(data['modified'])
+        if data['modified']
+        else ''
+    )
+    return (created, modified)
+
+
+def legacy_to_current_event_dict(data: dict) -> dict:
+    mapping = {
+        "Title": "title",
+        "ELIXIR Node": "node",
+        "Start Date": "date_start",
+        "End Date": "date_end",
+        "Event type": "type",
+        "Funding": "funding",
+        "Organising Institution/s": "organising_institution",
+        "Location (city, country)": parse_location,
+        "EXCELERATE WP": None,
+        "Target audience": "target_audience",
+        "Additional ELIXIR Platforms involved": "additional_platforms",
+        "ELIXIR Communities involved": "communities",
+        "No. of participants": "number_participants",
+        "No. of trainers/ facilitators": "number_trainers",
+        "Url to event page/ agenda": "url",
+        "node_main": "node_main",
+        "duration": "duration",
+        "status": "status",
+    }
+    return parse_with_mapping(data, mapping)
+
+
+def legacy_to_current_quality_or_demographic_dict(data: dict) -> dict:
+    mapping = {
+        "event_code": "event",
+        "Where did you see the course advertised?": None,
+        "What is your career stage?": "career_stage",
+        "What is your employment sector?": "employment_country",
+        "What is your country of employment?": "employment_country",
+        "What is your gender?": "gender",
+        "Have you used the tool(s)/resource(s) covered in the course before?": "used_resources_before",
+        "Will you use the tool(s)/resource(s) covered in the course again?": "used_resources_future",
+        "Would you recommend the course?": "recommend_course",
+        "Please tell us your overall rating for the entire course": "course_rating",
+        "May we contact you by email in the future for more feedback?": "email_contact",
+        "What part of the training did you enjoy the most?": None,
+        "What part of the training did you enjoy the least?": None,
+        "The balance of theoretical and practical content was": "balance",
+        "What other topics would you like to see covered in the future?": None,
+        "Any other comments?": None,
+    }
+    return parse_with_mapping(data, mapping)
+
+
+def legacy_to_current_impact_dict(data: dict) -> dict:
+    mapping = {
+        "event_code": "event",
+        "Which training event did you take part in?": None,
+        "How long ago did you attend the training?": "when_attend_training",
+        "What was your main reason for attending the training?": "main_attend_reason",
+        "What was your main reason for attending the training? (Other)": None,
+        "How often did you use the tool(s)/ resource(s), covered in the training, BEFORE attending the training?": "how_often_use_before",
+        "How often do you use the tool(s)/ resource(s), covered in the training, AFTER having attended the training?": "how_often_use_after",
+        "Do you feel that you are able to explain to others what you learnt in the training?": "able_to_explain",
+        "Do you feel that you are able to explain to others what you learnt in the training? (Other)": None,
+        "Are you now able to use the tool(s)/ resource(s) covered in the training:": "able_use_now",
+        "Are you now able to use the tool(s)/ resource(s) covered in the training: (Other)": None,
+        "How did the training event help with your work? [select all that apply]": "help_work",
+        "How did the training event help with your work? (Other)": None,
+        "Attending the training event led to/ facilitated: [select all that apply]": "attending_led_to",
+        "Attending the training event led to/ facilitated: (Other)": None,
+        "Please elaborate on any impact": None,
+        "How many people have you shared the skills and/or knowledge that you learned during the training, with?": "people_share_knowledge",
+        "Would you recommend the training to others?": "recommend_others",
+        "Any other comments?": None,
+    }
+    return parse_with_mapping(data, mapping)
+
+
+def parse_with_mapping(data: dict, mapping: dict) -> dict:
+    transforms = [
+        (
+            parse_entry(source_id, parse_value(target))
+            if type(target) == str
+            else parse_entry(source_id, target)
+        )
+        for source_id, target in mapping.items()
+        if target is not None
+    ]
+
+    result = dict()
+    for transform in transforms:
+        result.update(transform(data))
+    return result
+
+
+def parse_value(target_id, transform=None) -> dict:
+    def _parse_value(value):
+        return {
+            target_id: (
+                value
+                if transform is None
+                else transform(value)
+            )
+        }
+    return _parse_value
+
+
+def parse_entry(source_id, parse_value):
+    def _parse_entry(data):
+        return parse_value(data[source_id])
+    return _parse_entry
+
+
+def parse_location(data: dict) -> dict:
+    location = data["location"]
+    [city, country] = [value.strip() for value in location.split(",")]
+    return {
+        "location_city": city,
+        "location_country": country
+    }

--- a/metrics/import_utils.py
+++ b/metrics/import_utils.py
@@ -1,21 +1,22 @@
 from datetime import datetime
 from metrics.models import Event, Demographic, Quality, Impact, User, Node
 from django.utils.text import slugify
+from django.core.exceptions import ValidationError, PermissionDenied
 
 
 class ImportContext:
-    def __init__(self, user=None, node_main=None):
-        self._user = user
-        self._node_main = node_main
-
     def event_from_dict(self, data: dict):
-        (created, modified) = timestamps_from_dict(data)
+        (created, modified) = self.timestamps_from_data(data)
 
         event = Event.objects.create(
             user=self.user_from_data(data),
             created=created,
             modified=modified,
-            code=slugify(data['code']),
+            code=(
+                slugify(data['code'])
+                if 'code' in data
+                else None
+            ),
             title=data['title'],
             node_main=self.node_from_data(data),
             date_start=convert_to_date(data['date_start']),
@@ -28,8 +29,8 @@ class ImportContext:
             target_audience=csv_to_array(data['target_audience']),
             additional_platforms=csv_to_array(data['additional_platforms']),
             communities=csv_to_array(data['communities']),
-            number_participants=data['number_participants'],
-            number_trainers=data['number_trainers'],
+            number_participants=int(data['number_participants'] or 0),
+            number_trainers=int(data['number_trainers'] or 0),
             url=data['url'],
             status=data['status'],
         )
@@ -45,12 +46,13 @@ class ImportContext:
         return event
 
     def demographic_from_dict(self, data: dict):
-        (created, modified) = timestamps_from_dict(data)
+        (created, modified) = self.timestamps_from_data(data)
+        (user, event) = self.get_user_and_event(data)
         demographic = Demographic.objects.create(
-            user=self.user_from_data(data),
+            user=user,
             created=created,
             modified=modified,
-            event=Event.objects.get(code=int(data['event'])),
+            event=event,
             heard_from=csv_to_array(data['heard_from']),
             employment_sector=data['employment_sector'],
             employment_country=data['employment_country'],
@@ -60,12 +62,13 @@ class ImportContext:
         return demographic
 
     def quality_from_dict(self, data: dict):
-        (created, modified) = timestamps_from_dict(data)
+        (created, modified) = self.timestamps_from_data(data)
+        (user, event) = self.get_user_and_event(data)
         quality = Quality.objects.create(
-            user=self.user_from_data(data),
+            user=user,
             created=created,
             modified=modified,
-            event=Event.objects.get(code=data['event']),
+            event=event,
             used_resources_before=data['used_resources_before'],
             used_resources_future=data['used_resources_future'],
             recommend_course=data['recommend_course'],
@@ -76,12 +79,13 @@ class ImportContext:
         return quality
 
     def impact_from_dict(self, data: dict):
-        (created, modified) = timestamps_from_dict(data)
+        (created, modified) = self.timestamps_from_data(data)
+        (user, event) = self.get_user_and_event(data)
         impact = Impact.objects.create(
-            user=self.user_from_data(data),
+            user=user,
             created=created,
             modified=modified,
-            event=Event.objects.get(code=data['event']),
+            event=event,
             when_attend_training=data['when_attend_training'],
             main_attend_reason=data['main_attend_reason'],
             how_often_use_before=data['how_often_use_before'],
@@ -94,26 +98,65 @@ class ImportContext:
             recommend_others=data['recommend_others'],
         )
         return impact
+    
+    def get_user_and_event(self, data: dict):
+        event = self.get_event(data['event'])
+        user = self.user_from_data(data)
+        self.assert_can_change_data(user, event)
+        return (user, event)
+    
+    def get_event(self, identifier):
+        return Event.objects.get(code=identifier)
 
     def user_from_data(self, data: dict):
-        return (
-            User.objects.get(username=data['user'])
-            if self._user is None
-            else self._user
-        )
+        return User.objects.get(username=data['user'])
 
     def node_from_data(self, data: dict):
         node_main = data['node_main'] if data['node_main'] else ''
         return (
             Node.objects.get(
                 name=node_main
-            ) if node_main and self._node_main is None
-            else self._node_main
+            ) if node_main
+            else None
+        )
+    
+    def timestamps_from_data(self, data: dict):
+        return timestamps_from_dict(data)
+    
+    def assert_can_change_data(self, user, event):
+        pass
+
+
+class LegacyImportContext(ImportContext):
+    def __init__(self, user=None, node_main=None, timestamps=None):
+        self._user = user
+        self._node_main = node_main
+        self._timestamps = timestamps
+
+    def quality_or_demographic_from_dict(self, data: dict):
+        return (
+            self.quality_from_dict(data),
+            self.demographic_from_dict(data)
         )
 
-    @staticmethod
-    def from_request(request):
-        return ImportContext(user=request.user)
+    def get_event(self, identifier):
+        return Event.objects.get(id=int(identifier))
+
+    def user_from_data(self, data: dict):
+        return self._user
+
+    def node_from_data(self, data: dict):
+        return self._node_main
+    
+    def timestamps_from_data(self, data: dict):
+        return self._timestamps
+    
+    def assert_can_change_data(self, user, event):
+        if user.get_node() != event.node_main:
+            raise PermissionDenied(
+                f"The metrics for the event {event.id}, {event.code} can not"
+                f" be updated by the current user: {user.username}"
+            )
 
 
 def csv_to_array(csv_string):
@@ -121,137 +164,140 @@ def csv_to_array(csv_string):
 
 
 def convert_to_timestamp(date_string):
-    return datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S').timestamp()
+    try:
+        return datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S').timestamp()
+    except ValueError as e:
+        raise ValidationError(f"Failed to parse timestamp: {e}")
 
 
 def convert_to_date(date_string):
-    return datetime.strptime(date_string, '%Y-%m-%d').date()
+    try:
+        return datetime.strptime(date_string, '%Y-%m-%d').date()
+    except ValueError as e:
+        raise ValidationError(f"Failed to parse date: {e}")
 
 
 def timestamps_from_dict(data: dict):
     created = (
         convert_to_timestamp(data['created'])
-        if data['created']
+        if data.get('created')
         else ''
     )
     modified = (
         convert_to_timestamp(data['modified'])
-        if data['modified']
+        if data.get('modified')
         else ''
     )
     return (created, modified)
 
 
 def legacy_to_current_event_dict(data: dict) -> dict:
-    mapping = {
-        "Title": "title",
-        "ELIXIR Node": "node",
-        "Start Date": "date_start",
-        "End Date": "date_end",
-        "Event type": "type",
-        "Funding": "funding",
-        "Organising Institution/s": "organising_institution",
-        "Location (city, country)": parse_location,
-        "EXCELERATE WP": None,
-        "Target audience": "target_audience",
-        "Additional ELIXIR Platforms involved": "additional_platforms",
-        "ELIXIR Communities involved": "communities",
-        "No. of participants": "number_participants",
-        "No. of trainers/ facilitators": "number_trainers",
-        "Url to event page/ agenda": "url",
-        "node_main": "node_main",
-        "duration": "duration",
-        "status": "status",
-    }
-    return parse_with_mapping(data, mapping)
+    try:
+        mapping = {
+            "Title": "title",
+            "ELIXIR Node": "node",
+            "Start Date": "date_start",
+            "End Date": "date_end",
+            "Event type": "type",
+            "Funding": "funding",
+            "Organising Institution/s": "organising_institution",
+            "Location (city, country)": None,
+            "EXCELERATE WP": None,
+            "Target audience": "target_audience",
+            "Additional ELIXIR Platforms involved": "additional_platforms",
+            "ELIXIR Communities involved": "communities",
+            "No. of participants": "number_participants",
+            "No. of trainers/ facilitators": "number_trainers",
+            "Url to event page/ agenda": "url",
+        }
+        return {
+            **{
+                target_id: data[source_id]
+                for source_id, target_id in mapping.items()
+                if target_id is not None
+            },
+            **parse_location(data["Location (city, country)"]),
+            "node_main": None,
+            "duration": 0,
+            "status": "Complete",
+        }
+    except KeyError as e:
+        raise ValidationError(f"Missing source data '{e}'")
 
 
 def legacy_to_current_quality_or_demographic_dict(data: dict) -> dict:
-    mapping = {
-        "event_code": "event",
-        "Where did you see the course advertised?": None,
-        "What is your career stage?": "career_stage",
-        "What is your employment sector?": "employment_country",
-        "What is your country of employment?": "employment_country",
-        "What is your gender?": "gender",
-        "Have you used the tool(s)/resource(s) covered in the course before?": "used_resources_before",
-        "Will you use the tool(s)/resource(s) covered in the course again?": "used_resources_future",
-        "Would you recommend the course?": "recommend_course",
-        "Please tell us your overall rating for the entire course": "course_rating",
-        "May we contact you by email in the future for more feedback?": "email_contact",
-        "What part of the training did you enjoy the most?": None,
-        "What part of the training did you enjoy the least?": None,
-        "The balance of theoretical and practical content was": "balance",
-        "What other topics would you like to see covered in the future?": None,
-        "Any other comments?": None,
-    }
-    return parse_with_mapping(data, mapping)
+    try:
+        mapping = {
+            "event_code": "event",
+            "Where did you see the course advertised?": "heard_from",
+            "What is your career stage?": "career_stage",
+            "What is your employment sector?": "employment_sector",
+            "What is your country of employment?": "employment_country",
+            "What is your gender?": "gender",
+            "Have you used the tool(s)/resource(s) covered in the course before?": "used_resources_before",
+            "Will you use the tool(s)/resource(s) covered in the course again?": "used_resources_future",
+            "Would you recommend the course?": "recommend_course",
+            "Please tell us your overall rating for the entire course": "course_rating",
+            "May we contact you by email in the future for more feedback?": "email_contact",
+            "What part of the training did you enjoy the most?": None,
+            "What part of the training did you enjoy the least?": None,
+            "The balance of theoretical and practical content was": "balance",
+            "What other topics would you like to see covered in the future?": None,
+            "Any other comments?": None,
+        }
+        return {
+            **{
+                target_id: data[source_id]
+                for source_id, target_id in mapping.items()
+                if target_id is not None
+            },
+            "event": int(data["event_code"])
+        }
+    except KeyError as e:
+        raise ValidationError(f"Missing source data '{e}'")
 
 
 def legacy_to_current_impact_dict(data: dict) -> dict:
-    mapping = {
-        "event_code": "event",
-        "Which training event did you take part in?": None,
-        "How long ago did you attend the training?": "when_attend_training",
-        "What was your main reason for attending the training?": "main_attend_reason",
-        "What was your main reason for attending the training? (Other)": None,
-        "How often did you use the tool(s)/ resource(s), covered in the training, BEFORE attending the training?": "how_often_use_before",
-        "How often do you use the tool(s)/ resource(s), covered in the training, AFTER having attended the training?": "how_often_use_after",
-        "Do you feel that you are able to explain to others what you learnt in the training?": "able_to_explain",
-        "Do you feel that you are able to explain to others what you learnt in the training? (Other)": None,
-        "Are you now able to use the tool(s)/ resource(s) covered in the training:": "able_use_now",
-        "Are you now able to use the tool(s)/ resource(s) covered in the training: (Other)": None,
-        "How did the training event help with your work? [select all that apply]": "help_work",
-        "How did the training event help with your work? (Other)": None,
-        "Attending the training event led to/ facilitated: [select all that apply]": "attending_led_to",
-        "Attending the training event led to/ facilitated: (Other)": None,
-        "Please elaborate on any impact": None,
-        "How many people have you shared the skills and/or knowledge that you learned during the training, with?": "people_share_knowledge",
-        "Would you recommend the training to others?": "recommend_others",
-        "Any other comments?": None,
-    }
-    return parse_with_mapping(data, mapping)
-
-
-def parse_with_mapping(data: dict, mapping: dict) -> dict:
-    transforms = [
-        (
-            parse_entry(source_id, parse_value(target))
-            if type(target) == str
-            else parse_entry(source_id, target)
-        )
-        for source_id, target in mapping.items()
-        if target is not None
-    ]
-
-    result = dict()
-    for transform in transforms:
-        result.update(transform(data))
-    return result
-
-
-def parse_value(target_id, transform=None) -> dict:
-    def _parse_value(value):
-        return {
-            target_id: (
-                value
-                if transform is None
-                else transform(value)
-            )
+    try:
+        mapping = {
+            "event_code": "event",
+            "Which training event did you take part in?": None,
+            "How long ago did you attend the training?": "when_attend_training",
+            "What was your main reason for attending the training?": "main_attend_reason",
+            "What was your main reason for attending the training? (Other)": None,
+            "How often did you use the tool(s)/ resource(s), covered in the training, BEFORE attending the training?": "how_often_use_before",
+            "How often do you use the tool(s)/ resource(s), covered in the training, AFTER having attended the training?": "how_often_use_after",
+            "Do you feel that you are able to explain to others what you learnt in the training?": "able_to_explain",
+            "Do you feel that you are able to explain to others what you learnt in the training? (Other)": None,
+            "Are you now able to use the tool(s)/ resource(s) covered in the training:": "able_use_now",
+            "Are you now able to use the tool(s)/ resource(s) covered in the training: (Other)": None,
+            "How did the training event help with your work? [select all that apply]": "help_work",
+            "How did the training event help with your work? (Other)": None,
+            "Attending the training event led to/ facilitated: [select all that apply]": "attending_led_to",
+            "Attending the training event led to/ facilitated: (Other)": None,
+            "Please elaborate on any impact": None,
+            "How many people have you shared the skills and/or knowledge that you learned during the training, with?": "people_share_knowledge",
+            "Would you recommend the training to others?": "recommend_others",
+            "Any other comments?": None,
         }
-    return _parse_value
+        return {
+            **{
+                target_id: data[source_id]
+                for source_id, target_id in mapping.items()
+                if target_id is not None
+            },
+            "event": int(data["event_code"])
+        }
+    except KeyError as e:
+        raise ValidationError(f"Missing source data '{e}'")
 
 
-def parse_entry(source_id, parse_value):
-    def _parse_entry(data):
-        return parse_value(data[source_id])
-    return _parse_entry
-
-
-def parse_location(data: dict) -> dict:
-    location = data["location"]
-    [city, country] = [value.strip() for value in location.split(",")]
-    return {
-        "location_city": city,
-        "location_country": country
-    }
+def parse_location(location: str) -> dict:
+    try:
+        [city, country] = [value.strip() for value in location.split(",")]
+        return {
+            "location_city": city,
+            "location_country": country
+        }
+    except ValueError as e:
+        raise ValidationError(f"Failed to parse location: {e}")

--- a/metrics/import_utils.py
+++ b/metrics/import_utils.py
@@ -22,17 +22,17 @@ class ImportContext:
             date_start=convert_to_date(data['date_start']),
             date_end=convert_to_date(data['date_end']),
             duration=float(data['duration']),
-            type=data['type'],
-            funding=csv_to_array(data['funding']),
-            location_city=data['location_city'],
+            type=use_alias(data['type']),
+            funding=csv_to_array(data['funding']) or ["ELIXIR Node"],
+            location_city=data['location_city'] or "NA",
             location_country=data['location_country'],
-            target_audience=csv_to_array(data['target_audience']),
-            additional_platforms=csv_to_array(data['additional_platforms']),
-            communities=csv_to_array(data['communities']),
+            target_audience=csv_to_array(data['target_audience']) or ["Academia / Research Institution"],
+            additional_platforms=csv_to_array(data['additional_platforms']) or ["NA"],
+            communities=csv_to_array(data['communities']) or ["NA"],
             number_participants=int(data['number_participants'] or 0),
             number_trainers=int(data['number_trainers'] or 0),
             url=data['url'],
-            status=data['status'],
+            status=use_alias(data['status']),
         )
         # event.organising_institution.set([data['organising_institution']])
         node_names = data['node'].split(",")
@@ -54,11 +54,11 @@ class ImportContext:
             created=created,
             modified=modified,
             event=event,
-            heard_from=csv_to_array(data['heard_from']),
-            employment_sector=data['employment_sector'],
+            heard_from=csv_to_array(data['heard_from']) or ["Other"],
+            employment_sector=data['employment_sector'] or "Other",
             employment_country=data['employment_country'],
-            gender=data['gender'],
-            career_stage=data['career_stage'],
+            gender=data['gender'] or "Other",
+            career_stage=data['career_stage'] or "Other",
         )
         demographic.full_clean()
         return demographic
@@ -76,7 +76,7 @@ class ImportContext:
             recommend_course=data['recommend_course'],
             course_rating=data['course_rating'],
             balance=data['balance'],
-            email_contact=data['email_contact'],
+            email_contact=data['email_contact'] or "No",
         )
         quality.full_clean()
         return quality
@@ -90,13 +90,13 @@ class ImportContext:
             modified=modified,
             event=event,
             when_attend_training=data['when_attend_training'],
-            main_attend_reason=data['main_attend_reason'],
+            main_attend_reason=use_alias(data['main_attend_reason']),
             how_often_use_before=data['how_often_use_before'],
             how_often_use_after=data['how_often_use_after'],
-            able_to_explain=data['able_to_explain'],
-            able_use_now=data['able_use_now'],
-            help_work=csv_to_array(data['help_work']),
-            attending_led_to=csv_to_array(data['attending_led_to']),
+            able_to_explain=data['able_to_explain'] or "Other",
+            able_use_now=use_alias(data['able_use_now']) or "Other",
+            help_work=csv_to_array(data['help_work']) or ["Other"],
+            attending_led_to=csv_to_array(data['attending_led_to']) or ["Other"],
             people_share_knowledge=data['people_share_knowledge'],
             recommend_others=data['recommend_others'],
         )
@@ -163,8 +163,33 @@ class LegacyImportContext(ImportContext):
             )
 
 
+def use_alias(value):
+    aliases = {
+        "academia/ research institution": "Academia / Research Institution",
+        "non-profit organisation": "Non-profit Organisation",
+        "complete": "Complete",
+        "non-elixir/ non-excelerate funds": "Non-ELIXIR / Non-EXCELERATE Funds",
+        "training - elearning": "Training - e-learning",
+        "converge": "ELIXIR Converge",
+        "eosc-life": "EOSC Life",
+        "knowledge exchange workshop": "Knowledge Exchange Workshop",
+        "elixir community/ use case": "ELIXIR Community / Use case",
+        "to learn something new to aid me in my current research/ work": "To learn something new to aid me in my current research/work",
+        "by using training materials/ notes from the training event": "By using training materials/notes from the training event",
+        "to build an existing knowledge to aid me in my current research/ work": "To build on existing knowledge to aid me in my current research/work",
+        "useful collaboration(s) with other participants/ trainers from the training event": "Useful collaboration(s) with other participants/trainers from the training event",
+        "it improved communication with the bioinformatician/ statistician analyzing my data": "It improved communication with the bioinformatician/statistician analyzing my data",
+        "it did not help as i do not use the tool(s)/ resource(s) covered in the training event": "It did not help as I do not use the tool(s)/resource(s) covered in the training event",
+        "submission of my dissertation/ thesis for degree purposes": "Submission of my dissertation/thesis for degree purposes",
+    }
+    return aliases.get(value.lower(), value)
+
+
 def csv_to_array(csv_string):
-    return [x.strip() for x in csv_string.split(",")] if csv_string else []
+    return [
+        use_alias(x.strip())
+        for x in csv_string.split(",")
+    ] if csv_string else []
 
 
 def convert_to_timestamp(date_string):

--- a/metrics/management/commands/create_test_data.py
+++ b/metrics/management/commands/create_test_data.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from uuid import uuid4
 from metrics import import_utils, models
 import csv
+import random
 
 
 class Command(BaseCommand):
@@ -54,6 +55,45 @@ class Command(BaseCommand):
                 })
                 for row in test_data:
                     writer.writerow(row)
+    
+    def get_institutions(self):
+        institutions = [
+            "https://ror.org/0576by029",
+            "https://ror.org/05g3p2p60",
+            "https://ror.org/0576by029",
+            "https://ror.org/05g3p2p60",
+            "https://ror.org/03xrhmk39",
+            "https://ror.org/02hpadn98",
+            "https://ror.org/01h1jbk91",
+            "https://ror.org/03bndpq63",
+            "https://ror.org/045f7pv37",
+            "https://ror.org/03mstc592",
+            "https://ror.org/02catss52",
+            "https://ror.org/04wfr2810",
+            "https://ror.org/03mstc592",
+            "https://ror.org/045f7pv37",
+            "https://ror.org/02nv7yv05",
+            "https://ror.org/052rphn09",
+            "https://ror.org/045f7pv37",
+            "https://ror.org/03bndpq63",
+            "https://ror.org/045f7pv37",
+            "https://ror.org/03bndpq63",
+            "https://ror.org/00enajs79",
+            "https://ror.org/033m02g29",
+            "https://ror.org/002n09z45",
+            "https://ror.org/05f0yaq80",
+            "https://ror.org/01fapfv42",
+            "https://ror.org/02495e989",
+            "https://ror.org/05kb8h459",
+            "https://ror.org/048a87296",
+            "https://ror.org/008x57b05",
+            "https://ror.org/027m9bs27",
+            "https://ror.org/03z77qz90",
+            "https://ror.org/048a87296",
+            "https://ror.org/03xrhmk39",
+        ]
+
+        return ",".join(random.choices(institutions, k=random.randint(1,3)))
 
     def get_location(self):
         return "Neverland, Queenstown"
@@ -77,7 +117,6 @@ class Command(BaseCommand):
         event_mapping = {
             "Event type": "type",
             "Funding": "funding",
-            "Organising Institution/s": "organising_institution",
             "Target audience": "target_audience",
             "Additional ELIXIR Platforms involved": "additional_platforms",
             "ELIXIR Communities involved": "communities",
@@ -103,6 +142,7 @@ class Command(BaseCommand):
                 "Location (city, country)": self.get_location,
                 "Start Date": self.get_end_date,
                 "End Date": self.get_start_date,
+                "Organising Institution/s": self.get_institutions
             }
         )
         return (

--- a/metrics/management/commands/create_test_data.py
+++ b/metrics/management/commands/create_test_data.py
@@ -1,0 +1,269 @@
+from django.core.management.base import BaseCommand
+from uuid import uuid4
+from metrics import import_utils, models
+import csv
+
+
+class Command(BaseCommand):
+    help = 'Create test data for upload'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--targetdir",
+            type=str,
+            required=False,
+            default="test-data"
+        )
+        parser.add_argument(
+            "--events",
+            type=int,
+            required=False,
+            default=5
+        )
+        parser.add_argument(
+            "--contextid",
+            type=str,
+            required=False,
+            default=uuid4()
+        )
+        parser.add_argument(
+            "--eventcodes",
+            type=str,
+            required=False,
+            default="1,2,3"
+        )
+
+    def handle(self, *args, **options):
+        target_dir = options["targetdir"]
+        events = options["events"]
+        context_id = options["contextid"]
+        event_codes = options["eventcodes"].split(",")
+        generators = [
+            (f"events-{context_id}.csv", self.create_event_data, (events,)),
+            (f"demographic_quality-{context_id}.csv", self.create_demographic_quality_metrics, (event_codes,)),
+            (f"impact-{context_id}.csv", self.create_impact_metrics, (event_codes,)),
+        ]
+
+        for file_name, generator, params in generators:
+            fieldnames, test_data = generator(*params)
+            with open(f"{target_dir}/{file_name}", "w") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writerow({
+                    fieldname: fieldname
+                    for fieldname in fieldnames
+                })
+                for row in test_data:
+                    writer.writerow(row)
+
+    def get_location(self):
+        return "Neverland, Queenstown"
+
+    def get_start_date(self):
+        return "2024-06-10"
+
+    def get_end_date(self):
+        return "2024-06-12"
+
+    def get_title(self):
+        return f"A cool event {uuid4()}"
+
+    def get_node(self):
+        return "ELIXIR-UK"
+
+    def get_url(self):
+        return "https://neverland.local"
+
+    def create_event_data(self, count):
+        event_mapping = {
+            "Event type": "type",
+            "Funding": "funding",
+            "Organising Institution/s": "organising_institution",
+            "Target audience": "target_audience",
+            "Additional ELIXIR Platforms involved": "additional_platforms",
+            "ELIXIR Communities involved": "communities",
+            "No. of participants": "number_participants",
+            "No. of trainers/ facilitators": "number_trainers",
+            "Url to event page/ agenda": "url",
+        }
+        test_data = import_utils.get_test_data_from_model(
+            models.Event,
+            [
+                (field_id, alias)
+                for (alias, field_id) in event_mapping.items()
+            ],
+            count
+        )
+        test_data = import_utils.update_table_rows(
+            test_data,
+            {
+                "Url to event page/ agenda": self.get_url,
+                "ELIXIR Node": self.get_node,
+                "Title": self.get_title,
+                "EXCELERATE WP": None,
+                "Location (city, country)": self.get_location,
+                "Start Date": self.get_end_date,
+                "End Date": self.get_start_date,
+            }
+        )
+        return (
+            [
+                "Title",
+                "ELIXIR Node",
+                "Start Date",
+                "End Date",
+                "Event type",
+                "Funding",
+                "Organising Institution/s",
+                "Location (city, country)",
+                "EXCELERATE WP",
+                "Target audience",
+                "Additional ELIXIR Platforms involved",
+                "ELIXIR Communities involved",
+                "No. of participants",
+                "No. of trainers/ facilitators",
+                "Url to event page/ agenda"
+            ],
+            test_data
+        )
+
+    def create_demographic_quality_metrics(self, event_codes):
+        count = len(event_codes)
+        demographic_mapping = {
+            "Where did you see the course advertised?": "heard_from",
+            "What is your career stage?": "career_stage",
+            "What is your employment sector?": "employment_sector",
+            "What is your country of employment?": "employment_country",
+            "What is your gender?": "gender",
+        }
+        quality_mapping = {
+            "Have you used the tool(s)/resource(s) covered in the course before?": "used_resources_before",
+            "Will you use the tool(s)/resource(s) covered in the course again?": "used_resources_future",
+            "Would you recommend the course?": "recommend_course",
+            "Please tell us your overall rating for the entire course": "course_rating",
+            "May we contact you by email in the future for more feedback?": "email_contact",
+            "The balance of theoretical and practical content was": "balance",
+        }
+
+        demographic_data = import_utils.get_test_data_from_model(
+            models.Demographic,
+            [
+                (field_id, alias)
+                for (alias, field_id) in demographic_mapping.items()
+            ],
+            count
+        )
+        quality_data = import_utils.get_test_data_from_model(
+            models.Quality,
+            [
+                (field_id, alias)
+                for (alias, field_id) in quality_mapping.items()
+            ],
+            count
+        )
+        combined_data = [
+            {
+                **ddr,
+                **qdr
+            }
+            for ddr, qdr in zip(demographic_data, quality_data)
+        ]
+        event_code_iterator = iter(event_codes)
+        test_data = import_utils.update_table_rows(
+            combined_data,
+            {
+                "event_code": lambda: next(event_code_iterator),
+                "Any other comments?": None,
+                "What other topics would you like to see covered in the future?": None,
+                "What part of the training did you enjoy the least?": None,
+                "What part of the training did you enjoy the most?": None,
+            }
+        )
+        return (
+            [
+                "event_code",
+                "Where did you see the course advertised?",
+                "What is your career stage?",
+                "What is your employment sector?",
+                "What is your country of employment?",
+                "What is your gender?",
+                "Have you used the tool(s)/resource(s) covered in the course before?",
+                "Will you use the tool(s)/resource(s) covered in the course again?",
+                "Would you recommend the course?",
+                "Please tell us your overall rating for the entire course",
+                "May we contact you by email in the future for more feedback?",
+                "What part of the training did you enjoy the most?",
+                "What part of the training did you enjoy the least?",
+                "The balance of theoretical and practical content was",
+                "What other topics would you like to see covered in the future?",
+                "Any other comments?",
+            ],
+            test_data
+        )
+
+    def create_impact_metrics(self, event_codes):
+        count = len(event_codes)
+        impact_mapping = {
+            "Which training event did you take part in?": None,
+            "How long ago did you attend the training?": "when_attend_training",
+            "What was your main reason for attending the training?": "main_attend_reason",
+            "What was your main reason for attending the training? (Other)": None,
+            "How often did you use the tool(s)/ resource(s), covered in the training, BEFORE attending the training?": "how_often_use_before",
+            "How often do you use the tool(s)/ resource(s), covered in the training, AFTER having attended the training?": "how_often_use_after",
+            "Do you feel that you are able to explain to others what you learnt in the training?": "able_to_explain",
+            "Do you feel that you are able to explain to others what you learnt in the training? (Other)": None,
+            "Are you now able to use the tool(s)/ resource(s) covered in the training:": "able_use_now",
+            "Are you now able to use the tool(s)/ resource(s) covered in the training: (Other)": None,
+            "How did the training event help with your work? [select all that apply]": "help_work",
+            "How did the training event help with your work? (Other)": None,
+            "Attending the training event led to/ facilitated: [select all that apply]": "attending_led_to",
+            "Attending the training event led to/ facilitated: (Other)": None,
+            "Please elaborate on any impact": None,
+            "How many people have you shared the skills and/or knowledge that you learned during the training, with?": "people_share_knowledge",
+            "Would you recommend the training to others?": "recommend_others",
+            "Any other comments?": None,
+        }
+        test_data = import_utils.get_test_data_from_model(
+            models.Impact,
+            [
+                (field_id, alias)
+                for (alias, field_id) in impact_mapping.items()
+                if field_id is not None
+            ],
+            count
+        )
+        event_code_iterator = iter(event_codes)
+        test_data = import_utils.update_table_rows(
+            test_data,
+            {
+                **{
+                    alias: None
+                    for (alias, field_id) in impact_mapping.items()
+                    if field_id is None
+                },
+                "event_code": lambda: next(event_code_iterator),
+            }
+        )
+        return (
+            [
+                "event_code",
+                "Which training event did you take part in?",
+                "How long ago did you attend the training?",
+                "What was your main reason for attending the training?",
+                "What was your main reason for attending the training? (Other)",
+                "How often did you use the tool(s)/ resource(s), covered in the training, BEFORE attending the training?",
+                "How often do you use the tool(s)/ resource(s), covered in the training, AFTER having attended the training?",
+                "Do you feel that you are able to explain to others what you learnt in the training?",
+                "Do you feel that you are able to explain to others what you learnt in the training? (Other)",
+                "Are you now able to use the tool(s)/ resource(s) covered in the training:",
+                "Are you now able to use the tool(s)/ resource(s) covered in the training: (Other)",
+                "How did the training event help with your work? [select all that apply]",
+                "How did the training event help with your work? (Other)",
+                "Attending the training event led to/ facilitated: [select all that apply]",
+                "Attending the training event led to/ facilitated: (Other)",
+                "Please elaborate on any impact",
+                "How many people have you shared the skills and/or knowledge that you learned during the training, with?",
+                "Would you recommend the training to others?",
+                "Any other comments?",
+            ],
+            test_data
+        )

--- a/metrics/management/commands/load_data.py
+++ b/metrics/management/commands/load_data.py
@@ -1,9 +1,7 @@
 import csv
-from datetime import datetime
-from django.utils.text import slugify
 from metrics.models import Event, Demographic, Quality, Impact, Node, OrganisingInstitution, User
+from metrics import import_utils
 from django.core.management.base import BaseCommand
-from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
@@ -20,18 +18,7 @@ def get_data_sources(targetdir="example-data"):
 
 
 DATA_SOURCES = get_data_sources()
-
-
-def convert_to_timestamp(date_string):
-    return datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S').timestamp()
-
-
-def convert_to_date(date_string):
-    return datetime.strptime(date_string, '%Y-%m-%d').date()
-
-
-def csv_to_array(csv_string):
-    return [x for x in csv_string.split(",")] if csv_string else []
+import_context = import_utils.ImportContext()
 
 
 def are_headers_in_model(csv_file_path, model):
@@ -51,116 +38,28 @@ def load_events():
     with open(DATA_SOURCES[Event], newline='') as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
         for row in reader:
-            created = convert_to_timestamp(
-                row['created']) if row['created'] else ''
-            modified = convert_to_timestamp(
-                row['modified']) if row['modified'] else ''
-
-            node_main = row['node_main'] if row['node_main'] else ''
-
-            event = Event.objects.create(
-                user=User.objects.get(username=row['user']),
-                created=created,
-                modified=modified,
-                code=slugify(row['code']),
-                title=row['title'],
-                node_main=Node.objects.get(
-                    name=node_main) if node_main else None,
-                date_start=convert_to_date(row['date_start']),
-                date_end=convert_to_date(row['date_end']),
-                duration=float(row['duration']),
-                type=row['type'],
-                funding=csv_to_array(row['funding']),
-                location_city=row['location_city'],
-                location_country=row['location_country'],
-                target_audience=csv_to_array(row['target_audience']),
-                additional_platforms=csv_to_array(row['additional_platforms']),
-                communities=csv_to_array(row['communities']),
-                number_participants=row['number_participants'],
-                number_trainers=row['number_trainers'],
-                url=row['url'],
-                status=row['status'],
-            )
-            # event.organising_institution.set([row['organising_institution']])
-            node_names = row['node'].split(",")
-            stripped_names = [name.strip() for name in node_names]
-            nodes = [Node.objects.get(name=node)
-                     for node in stripped_names]
-            event.node.add(*nodes)
-
-            # Adding ManyToMany relationship with OrganisingInstitution
-            # institutions = [OrganisingInstitution.objects.get(
-            #    name=inst) for inst in row['organising_institution'].split(",")]
-            # event.organising_institution.add(*institutions)
+            import_context.event_from_dict(row)
 
 
 def load_demographics():
     with open(DATA_SOURCES[Demographic], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            created = convert_to_timestamp(
-                row['created']) if row['created'] else ''
-            modified = convert_to_timestamp(
-                row['modified']) if row['modified'] else ''
-            Demographic.objects.create(
-                user=User.objects.get(username=row['user']),
-                created=created,
-                modified=modified,
-                event=Event.objects.get(code=int(row['event'])),
-                heard_from=csv_to_array(row['heard_from']),
-                employment_sector=row['employment_sector'],
-                employment_country=row['employment_country'],
-                gender=row['gender'],
-                career_stage=row['career_stage'],
-            )
+            import_context.demographic_from_dict(row)
 
 
 def load_qualities():
     with open(DATA_SOURCES[Quality], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            created = convert_to_timestamp(
-                row['created']) if row['created'] else ''
-            modified = convert_to_timestamp(
-                row['modified']) if row['modified'] else ''
-            Quality.objects.create(
-                user=User.objects.get(username=row['user']),
-                created=created,
-                modified=modified,
-                event=Event.objects.get(code=row['event']),
-                used_resources_before=row['used_resources_before'],
-                used_resources_future=row['used_resources_future'],
-                recommend_course=row['recommend_course'],
-                course_rating=row['course_rating'],
-                balance=row['balance'],
-                email_contact=row['email_contact'],
-            )
+            import_context.quality_from_dict(row)
 
 
 def load_impacts():
     with open(DATA_SOURCES[Impact], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            created = convert_to_timestamp(
-                row['created']) if row['created'] else ''
-            modified = convert_to_timestamp(
-                row['modified']) if row['modified'] else ''
-            Impact.objects.create(
-                user=User.objects.get(username=row['user']),
-                created=created,
-                modified=modified,
-                event=Event.objects.get(code=row['event']),
-                when_attend_training=row['when_attend_training'],
-                main_attend_reason=row['main_attend_reason'],
-                how_often_use_before=row['how_often_use_before'],
-                how_often_use_after=row['how_often_use_after'],
-                able_to_explain=row['able_to_explain'],
-                able_use_now=row['able_use_now'],
-                help_work=csv_to_array(row['help_work']),
-                attending_led_to=csv_to_array(row['attending_led_to']),
-                people_share_knowledge=row['people_share_knowledge'],
-                recommend_others=row['recommend_others'],
-            )
+            import_context.impact_from_dict(row)
 
 
 def load_user():

--- a/metrics/management/commands/load_data.py
+++ b/metrics/management/commands/load_data.py
@@ -24,9 +24,14 @@ import_context = import_utils.ImportContext()
 def are_headers_in_model(csv_file_path, model):
     with open(csv_file_path, newline='') as csvfile:
         reader = csv.DictReader(csvfile, delimiter=',')
-        model_attributes = (list(field.name for field in model._meta.fields +
-                                 model._meta.many_to_many))
-        headers = (reader.fieldnames)
+        model_attributes = sorted(
+            [
+                field.name
+                for field in model._meta.fields + model._meta.many_to_many
+                if field.name not in {"locked"}
+            ]
+        )
+        headers = sorted(reader.fieldnames)
         uncommon_headers = set(
             model_attributes).symmetric_difference(set(headers))
         if len(uncommon_headers) > 1:

--- a/metrics/management/commands/load_data.py
+++ b/metrics/management/commands/load_data.py
@@ -45,21 +45,24 @@ def load_demographics():
     with open(DATA_SOURCES[Demographic], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            import_context.demographic_from_dict(row)
+            if not is_empty(row):
+                import_context.demographic_from_dict(row)
 
 
 def load_qualities():
     with open(DATA_SOURCES[Quality], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            import_context.quality_from_dict(row)
+            if not is_empty(row):
+                import_context.quality_from_dict(row)
 
 
 def load_impacts():
     with open(DATA_SOURCES[Impact], newline='') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            import_context.impact_from_dict(row)
+            if not is_empty(row):
+                import_context.impact_from_dict(row)
 
 
 def load_user():
@@ -88,6 +91,16 @@ def load_institutions():
             OrganisingInstitution.objects.create(
                 name=row['name'],
             )
+
+
+def is_empty(items):
+    for key, value in items.items():
+        if (
+            key not in ["user", "created", "updated", "event"]
+            and value
+        ):
+            return False
+    return True
 
 
 class Command(BaseCommand):

--- a/metrics/management/commands/load_data.py
+++ b/metrics/management/commands/load_data.py
@@ -6,13 +6,20 @@ from django.core.management.base import BaseCommand
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-DATA_SOURCES = {Event:  'raw-tmd-data/example-data/tango_events.csv',
-                Demographic: 'raw-tmd-data/example-data/demographics.csv',
-                Quality: 'raw-tmd-data/example-data/qualities_old.csv',
-                Impact: 'raw-tmd-data/example-data/impacts.csv',
-                User: 'raw-tmd-data/example-data/users.csv',
-                OrganisingInstitution: 'raw-tmd-data/example-data/institutions.csv',
-                Node: 'raw-tmd-data/example-data/nodes.csv'}
+
+def get_data_sources(targetdir="example-data"):
+    return {
+        Event:  f'raw-tmd-data/{targetdir}/tango_events.csv',
+        Demographic: f'raw-tmd-data/{targetdir}/tango_demographics.csv',
+        Quality: f'raw-tmd-data/{targetdir}/tango_qualities.csv',
+        Impact: f'raw-tmd-data/{targetdir}/tango_impacts.csv',
+        User: f'raw-tmd-data/{targetdir}/users.csv',
+        OrganisingInstitution: f'raw-tmd-data/{targetdir}/institutions.csv',
+        Node: f'raw-tmd-data/{targetdir}/nodes.csv'
+    }
+
+
+DATA_SOURCES = get_data_sources()
 
 
 def convert_to_timestamp(date_string):
@@ -187,7 +194,18 @@ def load_institutions():
 class Command(BaseCommand):
     help = 'Load data from CSV files into the database.'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--targetdir",
+            type=str,
+            required=False,
+        )
+
     def handle(self, *args, **options):
+        global DATA_SOURCES
+        if options["targetdir"]:
+            DATA_SOURCES = get_data_sources(options["targetdir"])
+
         for model, csv_file_path in DATA_SOURCES.items():
             if model == User:
                 continue

--- a/metrics/middleware.py
+++ b/metrics/middleware.py
@@ -76,9 +76,7 @@ class EventGroup():
         if date_from is not None and date_to is not None:
             query = query.filter(date_start__range=[date_from, date_to]).filter(date_end__range=[date_from, date_to])
         if params.get("node_only") and self.use_node:
-            node = Node.objects.filter(name=self.use_node).values_list("pk", flat=True).first()
-            if node:
-                query = query.filter(node=node)
+            query = query.filter(node=self.use_node)
         
         related_values = list(query.values_list("node__name", "node_main__name", "organising_institution"))
         values = list(query.values())
@@ -182,9 +180,7 @@ class Group():
         if date_from is not None and date_to is not None:
             query = query.filter(event__date_start__range=[date_from, date_to]).filter(event__date_end__range=[date_from, date_to])
         if params.get("node_only") and self.use_node:
-            node = Node.objects.filter(name=self.use_node).values_list("pk", flat=True).first()
-            if node:
-                query = query.filter(event__node=node)
+            query = query.filter(event__node=self.use_node)
 
         result = list(query.values())
         return result
@@ -203,7 +199,7 @@ class Metrics():
 
 def get_metrics(request):
     node = (
-        f"ELIXIR-{request.user.username.upper()}"
+        request.user.get_node()
         if request.user.is_authenticated
         else None
     )
@@ -240,6 +236,7 @@ def get_metrics(request):
             },
             use_fields=[
                 "code",
+                "id",
                 "title",
                 "node",
                 "node_main",

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.contrib.postgres.fields import ArrayField
 from django.urls import reverse
 from django import forms
+import re
 
 
 def string_choices(choices):
@@ -411,9 +412,16 @@ class Node(models.Model):
         )
 
 
+def is_ror_id(value):
+    if re.match("^https://ror.org/[a-zA-Z0-9]+$", value):
+        return value
+    raise ValidationError("Not a valid ror id")
+
+
 class OrganisingInstitution(models.Model):
     name = models.TextField()
     country = models.TextField()
+    ror_id = models.URLField(max_length=512, unique=True, null=True, validators=[is_ror_id])
 
     def __str__(self):
         return (

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -49,13 +49,13 @@ class Event(models.Model):
         choices=string_choices([
             "ELIXIR Converge",
             "EOSC Life",
-            "EXCELLERATE",
+            "EXCELERATE",
             "ELIXIR Implementation Study",
             "ELIXIR Community / Use case",
             "ELIXIR Node",
             "ELIXIR Hub",
             "ELIXIR Platform",
-            "Non-ELIXIR / Non-EXCELLERATE Funds",
+            "Non-ELIXIR / Non-EXCELERATE Funds",
         ])
     ))
 
@@ -130,19 +130,20 @@ class Demographic(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     event = models.ForeignKey("Event", on_delete=models.CASCADE)
-    employment_country = models.TextField()
-    heard_from = ArrayField(base_field=models.TextField(),
-                            verbose_name="Where did you hear about this course?",
-                            choices=[
-                            ("TeSS", "TeSS"),
-                            ("Host Institute Website", "Host Institute Website"),
-                            ("Email", "Email"),
-                            ("Newsletter", "Newsletter"),
-                            ("Colleague", "Colleague"),
-                            ("Internet search", "Internet search"),
-                            ("Other", "Other"),
-                            ],
-                            )
+    employment_country = models.TextField(blank=True)
+    heard_from = ChoiceArrayField(base_field=models.TextField(
+            choices=string_choices([
+                "TeSS",
+                "Host Institute Website",
+                "Email",
+                "Newsletter",
+                "Colleague",
+                "Internet search",
+                "Other",
+            ]),
+        ),
+        verbose_name="Where did you hear about this course?",
+    )
 
     employment_sector = models.TextField(
         verbose_name="Employment sector",
@@ -185,6 +186,7 @@ class Quality(models.Model):
     modified = models.DateTimeField(auto_now=True)
     event = models.ForeignKey("Event", on_delete=models.CASCADE)
     used_resources_before = models.TextField(
+        blank=True,
         choices=[
             ("Frequently (weekly to daily)", "Frequently (weekly to daily)"),
             ("Occasionally (once in a while to monthly)",
@@ -197,6 +199,7 @@ class Quality(models.Model):
     )
 
     used_resources_future = models.TextField(
+        blank=True,
         choices=[
             ("Yes", "Yes"),
             ("No", "No"),
@@ -205,6 +208,7 @@ class Quality(models.Model):
     )
 
     recommend_course = models.TextField(
+        blank=True,
         choices=[
             ("Yes", "Yes"),
             ("No", "No"),
@@ -213,6 +217,7 @@ class Quality(models.Model):
     )
 
     course_rating = models.TextField(
+        blank=True,
         choices=[
             ("Poor (1)", "Poor (1)"),
             ("Satisfactory (2)", "Satisfactory (2)"),
@@ -229,6 +234,7 @@ class Quality(models.Model):
     ]
 
     balance = models.TextField(
+        blank=True,
         choices=[
             ("About right", "About right"),
             ("Too theoretical", "Too theoretical"),
@@ -345,20 +351,27 @@ class Impact(models.Model):
     event = models.ForeignKey("Event", on_delete=models.CASCADE)
     when_attend_training = models.TextField(
         choices=HOW_LONG_CHOICES)
-    main_attend_reason = models.TextField(choices=REASON_CHOICES)
+    main_attend_reason = models.TextField(blank=True, choices=REASON_CHOICES)
     how_often_use_before = models.TextField(
+        blank=True,
         choices=HOW_OFTEN_BEFORE_CHOICES)
     how_often_use_after = models.TextField(
+        blank=True,
         choices=HOW_OFTEN_AFTER_CHOICES)
     able_to_explain = models.TextField(choices=EXPLAIN_CHOICES)
     able_use_now = models.TextField(choices=ABLE_USE_NOW_CHOICES)
-    help_work = ArrayField(base_field=models.TextField(),
-                           choices=HELP_WORK_CHOICES)
-    attending_led_to = ArrayField(base_field=models.TextField(),
-                                  choices=ATTENDING_LED_TO_CHOICES)
+    help_work = ChoiceArrayField(
+        base_field=models.TextField(choices=HELP_WORK_CHOICES)
+    )
+    attending_led_to = ChoiceArrayField(
+        blank=True,
+        base_field=models.TextField(choices=ATTENDING_LED_TO_CHOICES)
+    )
     people_share_knowledge = models.TextField(
+        blank=True,
         choices=PEOPLE_SHARE_KNOWLEDGE_CHOICES)
     recommend_others = models.TextField(
+        blank=True,
         choices=RECOMMEND_OTHERS_CHOICES)
 
     def __str__(self):

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -48,8 +48,8 @@ class Event(models.Model):
     funding = ChoiceArrayField(base_field=models.TextField(
         choices=string_choices([
             "ELIXIR Converge",
-            "EOSC Life", "EOSC Life",
-            "EXCELLERATE", "EXCELLERATE",
+            "EOSC Life",
+            "EXCELLERATE",
             "ELIXIR Implementation Study",
             "ELIXIR Community / Use case",
             "ELIXIR Node",
@@ -387,6 +387,9 @@ class OrganisingInstitution(models.Model):
             if self.country
             else str(self.name)
         )
+
+    def get_absolute_url(self):
+        return reverse("institution-edit", kwargs={"pk": self.id})
 
 
 class User(AbstractUser):

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -102,6 +102,7 @@ class Event(models.Model):
             "Incomplete",
         ])
     )
+    locked = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{self.title} ({self.id}) ({self.code})"
@@ -145,6 +146,13 @@ class Event(models.Model):
             2: "Partial",
             3: "Full"
         }[count]
+    
+    @property
+    def is_locked(self):
+        return (
+            self.code is not None
+            or self.locked
+        )
 
 
 class Demographic(models.Model):

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -124,6 +124,27 @@ class Event(models.Model):
             self.date_end
         )
 
+    @property
+    def stats(self):
+        return [
+            (name, model.objects.filter(event=self).count())
+            for name, model in [
+                ("Quality metrics", Quality),
+                ("Impact metrics", Impact),
+                ("Demographic metrics", Demographic)
+            ]
+        ]
+
+    @property
+    def metrics_status(self):
+        count = sum([1 if v > 0 else 0 for _n, v in self.stats])
+        return {
+            0: "None",
+            1: "Partial",
+            2: "Partial",
+            3: "Full"
+        }[count]
+
 
 class Demographic(models.Model):
     user = models.ForeignKey("User", on_delete=models.CASCADE)

--- a/tmd/settings.py
+++ b/tmd/settings.py
@@ -15,7 +15,7 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = Path(BASE_DIR, 'templates')
-
+LOGIN_URL="login"
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.0.3
 psycopg2-binary==2.9.6
 crispy-bootstrap5==0.7
 django-crispy-forms==2.0
+django-countries==7.6.*

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,6 @@
 django==4.2.*
 django-plotly-dash==2.2.*
+numpy==1.26.*
 pandas==2.0.3
 psycopg2-binary==2.9.6
 crispy-bootstrap5==0.7

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.9.6
 crispy-bootstrap5==0.7
 django-crispy-forms==2.0
 django-countries==7.6.*
+requests


### PR DESCRIPTION
This PR tries to implement feature #36

## To test
- `docker compose up`
- go to: http://localhost:8000
- sign in as any node
- go to the tab [Upload data](http://localhost:8000/upload-data)
- upload your data one file at a time
- go to the tab [Edit events](http://localhost:8000/event/list)
- verify that you can edit your events
- verify that the event stats properly reflects what you uploaded

## Test dataset
A test data set `test-data.zip` which contains three example files. One for each type. In order to make the test data set work in your environment you must first upload the events and then map the rows of each metric entry to the event codes returned by the event upload.

[test-data.zip](https://github.com/user-attachments/files/15874052/test-data.zip)


## Note
There are some issues still remaining with this implementation when it comes to importing data entries from the csv files.

- How should `code` be assigned to imported events?
- How should `code` of imported events be communicated to the user?
- What is the `status` of an imported event?
- What is the `duration` of an imported event?
- In order for the system to work properly I assume that the field `code` needs a uniqueness requirement?
