### PR TITLE
feat: add aliases to field values matching original spec

### DIFF
--- a/metrics/import_utils.py
+++ b/metrics/import_utils.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from datetime import datetime
 from django.db.models import TextField
 from metrics.models import (
@@ -14,6 +15,12 @@ from django.utils.text import slugify
 from django.core.exceptions import ValidationError, PermissionDenied
 import random
 from typing import Callable
+import functools
+import csv
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class ImportContext:
@@ -41,7 +48,7 @@ class ImportContext:
             funding=csv_to_array(data['funding']) or ["ELIXIR Node"],
             location_city=data['location_city'] or "NA",
             location_country=data['location_country'],
-            target_audience=csv_to_array(data['target_audience']) or ["Academia / Research Institution"],
+            target_audience=csv_to_array(data['target_audience']) or ["Academia/ Research Institution"],
             additional_platforms=csv_to_array(data['additional_platforms']) or ["NA"],
             communities=csv_to_array(data['communities']) or ["NA"],
             number_participants=int(data['number_participants'] or 0),
@@ -75,12 +82,12 @@ class ImportContext:
         institution = self._institutions.get(ror_id)
         if institution is not None:
             return institution
-        
+
         existing_inst = OrganisingInstitution.objects.filter(ror_id=ror_id).first()
         if existing_inst is not None:
             self._institutions[ror_id] = existing_inst
             return existing_inst
-        
+
         new_inst = OrganisingInstitution(ror_id=ror_id)
         new_inst.update_ror_data()
         new_inst.save()
@@ -96,10 +103,10 @@ class ImportContext:
             modified=modified,
             event=event,
             heard_from=csv_to_array(data['heard_from']) or ["Other"],
-            employment_sector=data['employment_sector'] or "Other",
+            employment_sector=use_alias(data['employment_sector']) or "Other",
             employment_country=data['employment_country'],
-            gender=data['gender'] or "Other",
-            career_stage=data['career_stage'] or "Other",
+            gender=use_alias(data['gender']) or "Other",
+            career_stage=use_alias(data['career_stage']) or "Other",
         )
         demographic.full_clean()
         return demographic
@@ -112,12 +119,12 @@ class ImportContext:
             created=created,
             modified=modified,
             event=event,
-            used_resources_before=data['used_resources_before'],
-            used_resources_future=data['used_resources_future'],
-            recommend_course=data['recommend_course'],
-            course_rating=data['course_rating'],
-            balance=data['balance'],
-            email_contact=data['email_contact'] or "No",
+            used_resources_before=use_alias(data['used_resources_before']),
+            used_resources_future=use_alias(data['used_resources_future']),
+            recommend_course=use_alias(data['recommend_course']),
+            course_rating=use_alias(data['course_rating']),
+            balance=use_alias(data['balance']),
+            email_contact=use_alias(data['email_contact']) or "No",
         )
         quality.full_clean()
         return quality
@@ -130,16 +137,16 @@ class ImportContext:
             created=created,
             modified=modified,
             event=event,
-            when_attend_training=data['when_attend_training'],
+            when_attend_training=use_alias(data['when_attend_training']),
             main_attend_reason=use_alias(data['main_attend_reason']),
-            how_often_use_before=data['how_often_use_before'],
-            how_often_use_after=data['how_often_use_after'],
-            able_to_explain=data['able_to_explain'] or "Other",
+            how_often_use_before=use_alias(data['how_often_use_before']),
+            how_often_use_after=use_alias(data['how_often_use_after']),
+            able_to_explain=use_alias(data['able_to_explain']) or "Other",
             able_use_now=use_alias(data['able_use_now']) or "Other",
             help_work=csv_to_array(data['help_work']) or ["Other"],
             attending_led_to=csv_to_array(data['attending_led_to']) or ["Other"],
-            people_share_knowledge=data['people_share_knowledge'],
-            recommend_others=data['recommend_others'],
+            people_share_knowledge=use_alias(data['people_share_knowledge']),
+            recommend_others=use_alias(data['recommend_others']),
         )
         impact.full_clean()
         return impact
@@ -211,10 +218,31 @@ class LegacyImportContext(ImportContext):
             )
 
 
-def use_alias(value):
+def read_aliases(path):
+    aliases = {}
+    ignore_columns = {"field", "value"}
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            value = row["value"]
+            for (column, alias) in row.items():
+                if column not in ignore_columns and alias:
+                    simplified_alias = alias.lower().strip()
+                    existing_alias = aliases.get(simplified_alias)
+                    if existing_alias is None:
+                        aliases[simplified_alias] = value
+                    elif existing_alias != value:
+                        raise ValueError(
+                            f"Confliciting aliases for '{simplified_alias}': '{existing_alias}' <-> '{value}'"
+                        )
+    return aliases
+
+
+@functools.cache
+def get_aliases():
     aliases = {
-        "academia/ research institution": "Academia / Research Institution",
-        "non-profit organisation": "Non-profit Organisation",
+        "academia/ research institution": "Academia/ Research Institution",
+        "non-profit organisation": "Non-Profit Organisation",
         "complete": "Complete",
         "non-elixir/ non-excelerate funds": "Non-ELIXIR / Non-EXCELERATE Funds",
         "training - elearning": "Training - e-learning",
@@ -230,7 +258,28 @@ def use_alias(value):
         "it did not help as i do not use the tool(s)/ resource(s) covered in the training event": "It did not help as I do not use the tool(s)/resource(s) covered in the training event",
         "submission of my dissertation/ thesis for degree purposes": "Submission of my dissertation/thesis for degree purposes",
     }
-    return aliases.get(value.lower(), value)
+
+    aliases_path = getattr(settings, "VALUE_ALIASES_PATH", None)
+    if aliases_path is not None:
+        try:
+            aliases = read_aliases(aliases_path)
+            logger.info(f"Aliases loaded from: {aliases_path}")
+        except (FileNotFoundError, ValueError) as e:
+            logger.error(f"Failed to load aliases from: {aliases_path}: {str(e)}")
+
+    return aliases
+
+
+def use_alias(value):
+    aliases = get_aliases()
+    return (
+        [
+            aliases.get(value.lower(), v)
+            for v in value
+        ]
+        if type(value) is list
+        else aliases.get(value.lower(), value)
+    )
 
 
 def csv_to_array(csv_string):
@@ -387,7 +436,7 @@ def get_field_info(model, field_id):
             c[0]
             for c in field.choices
         ]
-        if type(field) == TextField and field.choices is not None
+        if type(field) is TextField and field.choices is not None
         else None
     )
     array_choices = (
@@ -395,13 +444,13 @@ def get_field_info(model, field_id):
             c[0]
             for c in field.base_field.choices
         ]
-        if type(field) == ChoiceArrayField
+        if type(field) is ChoiceArrayField
         else None
     )
     return {
         "id": field_id,
         "type": str(type(field)),
-        "multichoice": type(field) == ChoiceArrayField,
+        "multichoice": type(field) is ChoiceArrayField,
         "values": array_choices or text_choices,
     }
 

--- a/metrics/management/commands/make_alias_map.py
+++ b/metrics/management/commands/make_alias_map.py
@@ -1,0 +1,34 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from metrics.models import (
+    Event,
+    Demographic,
+    Quality,
+    Impact,
+)
+
+class Command(BaseCommand):
+    help = "Creates an initial value mapping csv"
+
+    def handle(self, *args, **options):
+        models = [
+            (Event, ["type", "funding", "target_audience", "additional_platforms", "communities", "status"]),
+            (Demographic, ["heard_from", "employment_sector", "gender", "career_stage"]),
+            (Quality, ["used_resources_before", "used_resources_future", "recommend_course", "course_rating", "balance", "email_contact"]),
+            (Impact, ["when_attend_training", "main_attend_reason", "how_often_use_before", "how_often_use_after", "able_to_explain", "able_use_now", "help_work", "attending_led_to", "people_share_knowledge", "recommend_others"]),
+        ]
+
+        print("field,value,alias")
+        for (model, fieldIds) in models:
+            modelName = model.__name__
+            for fieldId in fieldIds:
+                choices = model._meta.get_field(fieldId).choices or model._meta.get_field(fieldId).base_field.choices
+                if not choices:
+                    raise LookupError(f"No options for field {modelName}.{fieldId}")
+
+                values = [
+                    (f"{modelName}.{fieldId}", choice)
+                    for (choice, _c) in (choices or [])
+                ]
+                for (valueId, value) in values:
+                    print(f'"{valueId}","{value}","{value.lower()}"')

--- a/metrics/models.py
+++ b/metrics/models.py
@@ -65,9 +65,9 @@ class Event(models.Model):
 
     target_audience = ChoiceArrayField(base_field=models.TextField(
         choices=string_choices([
-            "Academia / Research Institution",
+            "Academia/ Research Institution",
             "Industry",
-            "Non-profit Organisation",
+            "Non-Profit Organisation",
             "Healthcare",
         ])
     ))

--- a/metrics/tests.py
+++ b/metrics/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/metrics/tests/test_import_utils.py
+++ b/metrics/tests/test_import_utils.py
@@ -1,0 +1,129 @@
+from django.test import TestCase
+from django.conf import settings
+from metrics.models import (
+    Node,
+    User,
+    Event,
+    Demographic,
+    Quality,
+    Impact,
+    ChoiceArrayField
+)
+from metrics.import_utils import ImportContext
+import csv
+
+
+# Create your tests here.
+class TestImportValues(TestCase):
+    def test_import_with_aliases(self):
+        node = Node.objects.create(name="Test", country="Anywhere")
+        user = User.objects.create(username="test")
+        event = self._create_event(user, node)
+
+        model_defs = self._read_spec_models()
+        context = ImportContext()
+        model_map = {
+            "Event": Event,
+            "Demographic": Demographic,
+            "Quality": Quality,
+            "Impact": Impact
+        }
+        model_import_map = {
+            "Event": context.event_from_dict,
+            "Demographic": context.demographic_from_dict,
+            "Quality": context.quality_from_dict,
+            "Impact": context.impact_from_dict
+        }
+        model_base_data = {
+            "Event": {
+                "user": user.username,
+                "title": "A basic event",
+                "node_main": node.name,
+                "date_start": "2024-01-01",
+                "date_end": "2024-01-02",
+                "duration": "2",
+                "location_city": "Anytown",
+                "location_country": "Anywhere",
+                "number_participants": "10",
+                "number_trainers": "10",
+                "url": "https://local.local",
+                "organising_institution": "",
+                "node": "Test",
+            },
+            "Demographic": {
+                "user": user.username,
+                "event": event.code,
+                "employment_country": "Anywhere",
+
+            },
+            "Quality": {
+                "user": user.username,
+                "event": event.code,
+            },
+            "Impact": {
+                "user": user.username,
+                "event": event.code,
+            }
+        }
+        for (model_id, model_def) in model_defs.items():
+            model = model_map[model_id]
+            model_import = model_import_map[model_id]
+            base_data = {
+                **model_base_data[model_id],
+                **{
+                    field_name: values[0]
+                    for (field_name, values) in model_def.items()
+                }
+            }
+            for (field_name, values) in model_def.items():
+                for value in values:
+                    model_import({
+                        **base_data,
+                        field_name: value
+                    })
+
+    def _create_event(self, user, node, title="A test event", code="test"):
+        event = Event.objects.create(
+            user=user,
+            title=title,
+            node_main=node,
+            date_start="2024-01-01",
+            date_end="2024-01-02",
+            duration=2,
+            location_city="Anytown",
+            location_country="Anywhere",
+            number_participants=10,
+            number_trainers=10,
+            funding=["ELIXIR Node"],
+            url="https://local.local",
+            code=code,
+            type="Hackathon",
+            target_audience=["Academia/ Research Institution"],
+            additional_platforms=["NA"],
+            communities=["NA"],
+            status="Complete",
+        )
+        event.node.set([event.id])
+        event.save()
+        return event
+
+    def _read_spec_models(self):
+        aliases_path = getattr(settings, "VALUE_ALIASES_PATH", None)
+        if aliases_path:
+            fields = {}
+            with open(aliases_path) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    field_id = row["field"]
+                    spec_value = row["spec"]
+                    if spec_value:
+                        fields[field_id] = fields.get(field_id, [])
+                        fields[field_id].append(spec_value)
+            model_defs = {}
+            for (field_id, values) in fields.items():
+                [model_id, field_name] = field_id.split(".")
+                model_defs[model_id] = model_defs.get(model_id, {})
+                model_defs[model_id][field_name] = values
+            return model_defs
+        else:
+            raise RuntimeError("No 'VALUE_ALIASES_PATH' specified")

--- a/tmd/settings.py
+++ b/tmd/settings.py
@@ -148,3 +148,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Dash specific options
 X_FRAME_OPTIONS = "SAMEORIGIN"
+
+
+# Load field value aliases from CSV
+VALUE_ALIASES_PATH = "tmd/value-aliases-spec.csv"

--- a/tmd/value-aliases-spec.csv
+++ b/tmd/value-aliases-spec.csv
@@ -1,0 +1,139 @@
+field,value,alias,spec
+Event.type,Training - face to face,training - face to face,Training - face to face
+Event.type,Training - e-learning,training - e-learning,Training - elearning
+Event.type,Training - blended,training - blended,Training - blended
+Event.type,Knowledge Exchange Workshop,knowledge exchange workshop,Knowledge exchange workshop
+Event.type,Hackathon,hackathon,Hackathon
+Event.funding,ELIXIR Converge,elixir converge,
+Event.funding,EOSC Life,eosc life,
+Event.funding,EXCELERATE,excelerate,EXCELERATE
+Event.funding,ELIXIR Implementation Study,elixir implementation study,ELIXIR Implementation Study
+Event.funding,ELIXIR Community / Use case,elixir community / use case,ELIXIR Community/ Use Case
+Event.funding,ELIXIR Node,elixir node,ELIXIR Node
+Event.funding,ELIXIR Hub,elixir hub,ELIXIR Hub
+Event.funding,ELIXIR Platform,elixir platform,ELIXIR Platform
+Event.funding,Non-ELIXIR / Non-EXCELERATE Funds,non-elixir / non-excelerate funds,Non-ELIXIR/ Non-EXCELERATE funds
+Event.target_audience,Academia/ Research Institution,academia / research institution,Academia/ Research Institution
+Event.target_audience,Industry,industry,Industry
+Event.target_audience,Non-Profit Organisation,non-profit organisation,Non-Profit Organisation
+Event.target_audience,Healthcare,healthcare,Healthcare
+Event.additional_platforms,Compute,compute,Compute
+Event.additional_platforms,Data,data,Data
+Event.additional_platforms,Interoperability,interoperability,Interoperability
+Event.additional_platforms,Tools,tools,Tools
+Event.additional_platforms,NA,na,NA
+Event.communities,Human Data,human data,Human Data
+Event.communities,Marine Metagenomics,marine metagenomics,Marine Metagenomics
+Event.communities,Rare Diseases,rare diseases,Rare Diseases
+Event.communities,Plant Sciences,plant sciences,Plant Sciences
+Event.communities,Proteomics,proteomics,Proteomics
+Event.communities,Metabolomics,metabolomics,Metabolomics
+Event.communities,Galaxy,galaxy,Galaxy
+Event.communities,NA,na,NA
+Event.status,Complete,complete,Complete
+Event.status,Incomplete,incomplete,Incomplete
+Demographic.heard_from,TeSS,tess,TeSS
+Demographic.heard_from,Host Institute Website,host institute website,Host Institute Website
+Demographic.heard_from,Email,email,Email
+Demographic.heard_from,Newsletter,newsletter,Newsletter
+Demographic.heard_from,Colleague,colleague,Colleague
+Demographic.heard_from,Internet search,internet search,Internet search
+Demographic.heard_from,Other,other,Other
+Demographic.employment_sector,Academia/ Research Institution,academia/ research institution,Academia/ Research Institution
+Demographic.employment_sector,Industry,industry,Industry
+Demographic.employment_sector,Non-Profit Organisation,non-profit organisation,Non-Profit Organisation
+Demographic.employment_sector,Healthcare,healthcare,Healthcare
+Demographic.employment_sector,Other,other,Other
+Demographic.gender,Male,male,Male
+Demographic.gender,Female,female,Female
+Demographic.gender,Other,other,Other
+Demographic.gender,Prefer not to say,prefer not to say,Prefer not to say
+Demographic.career_stage,Undergraduate student,undergraduate student,Undergraduate student
+Demographic.career_stage,Masters student,masters student,Masters student
+Demographic.career_stage,PhD candidate,phd candidate,PhD candidate
+Demographic.career_stage,Postdoctoral researcher,postdoctoral researcher,Postdoctoral researcher
+Demographic.career_stage,Senior scientist/ Principal investigator,senior scientist/ principal investigator,Senior scientist/ Principal investigator
+Demographic.career_stage,Research assistant/ Technician,research assistant/ technician,Research assistant/ Technician
+Demographic.career_stage,Other,other,Other
+Quality.used_resources_before,Frequently (weekly to daily),frequently (weekly to daily),Frequently (weekly to daily)
+Quality.used_resources_before,Occasionally (once in a while to monthly),occasionally (once in a while to monthly),Occasionally (once in a while to monthly)
+Quality.used_resources_before,Never - used other service,never - used other service,Never - used other service
+Quality.used_resources_before,"Never - aware of them, but not used them","never - aware of them, but not used them","Never - aware of them, but not used them"
+Quality.used_resources_before,Never - unaware of them,never - unaware of them,Never - unaware of them
+Quality.used_resources_future,Yes,yes,Yes
+Quality.used_resources_future,No,no,No
+Quality.used_resources_future,Maybe,maybe,Maybe
+Quality.recommend_course,Yes,yes,Yes
+Quality.recommend_course,No,no,No
+Quality.recommend_course,Maybe,maybe,Maybe
+Quality.course_rating,Poor (1),poor (1),Poor (1)
+Quality.course_rating,Satisfactory (2),satisfactory (2),Satisfactory (2)
+Quality.course_rating,Good (3),good (3),Good (3)
+Quality.course_rating,Very Good (4),very good (4),Very Good (4)
+Quality.course_rating,Excellent (5),excellent (5),Excellent (5)
+Quality.balance,About right,about right,About right
+Quality.balance,Too theoretical,too theoretical,Too theoretical
+Quality.balance,Too practical,too practical,Too practical
+Quality.email_contact,Yes,yes,Yes
+Quality.email_contact,No,no,No
+Impact.when_attend_training,Less than 6 months,less than 6 months,Less than 6 months
+Impact.when_attend_training,6 months to a year,6 months to a year,6 months to a year
+Impact.when_attend_training,Over a year,over a year,Over a year
+Impact.main_attend_reason,To learn something new to aid me in my current research/work,to learn something new to aid me in my current research/work,To learn something new to aid me in my current research/ work
+Impact.main_attend_reason,To learn something new for my own interests,to learn something new for my own interests,To learn something new for my own interests
+Impact.main_attend_reason,To build on existing knowledge to aid me in my current research/work,to build on existing knowledge to aid me in my current research/work,To build on existing knowledge to aid me in my current research/ work
+Impact.main_attend_reason,To build on existing knowledge for my own interests,to build on existing knowledge for my own interests,To build on existing knowledge for my own interests
+Impact.main_attend_reason,Other,other,Other
+Impact.how_often_use_before,Never - unaware of them,never - unaware of them,Never - unaware of them
+Impact.how_often_use_before,"Never - aware of them, but had not used them","never - aware of them, but had not used them","Never - aware of them, but had not used them"
+Impact.how_often_use_before,Never - used other service,never - used other service,Never - used other service
+Impact.how_often_use_before,Occasionally (once in a while to monthly),occasionally (once in a while to monthly),Occasionally (once in a while to monthly)
+Impact.how_often_use_before,Frequently (weekly to daily),frequently (weekly to daily),Frequently (weekly to daily)
+Impact.how_often_use_after,Never - use other service,never - use other service,Never - use other service
+Impact.how_often_use_after,Occasionally (once in a while to monthly),occasionally (once in a while to monthly),Occasionally (once in a while to monthly)
+Impact.how_often_use_after,Frequently (weekly to daily),frequently (weekly to daily),Frequently (weekly to daily)
+Impact.able_to_explain,Yes,yes,Yes
+Impact.able_to_explain,No,no,No
+Impact.able_to_explain,Maybe,maybe,Maybe
+Impact.able_to_explain,Other,other,Other
+Impact.able_use_now,Independently,independently,Independently
+Impact.able_use_now,By using training materials/notes from the training event,by using training materials/notes from the training event,By using training materials/ notes from the training event
+Impact.able_use_now,With the help of an expert,with the help of an expert,With the help of an expert
+Impact.able_use_now,Other,other,Other
+Impact.help_work,It did not help as I do not use the tool(s)/resource(s) covered in the training event,it did not help as i do not use the tool(s)/resource(s) covered in the training event,It did not help as I do not use the tool(s)/ resource(s) covered in the training event
+Impact.help_work,It enabled me to complete certain tasks more quickly,it enabled me to complete certain tasks more quickly,It enabled me to complete certain tasks more quickly
+Impact.help_work,It has not helped yet but I anticipate a future impact,it has not helped yet but i anticipate a future impact,It has not helped yet but I anticipate a future impact
+Impact.help_work,It improved communication with the bioinformatician/statistician analyzing my data,it improved communication with the bioinformatician/statistician analyzing my data,It improved communication with the bioinformatician/ statistician analyzing my data
+Impact.help_work,It improved my ability to handle data,it improved my ability to handle data,It improved my ability to handle data
+Impact.help_work,Other,other,Other
+Impact.attending_led_to,Authoring of software,authoring of software,Authoring of software
+Impact.attending_led_to,Change in career,change in career,Change in career
+Impact.attending_led_to,Not applicable,not applicable,Not applicable
+Impact.attending_led_to,Other,other,Other
+Impact.attending_led_to,Publication of my work,publication of my work,Publication of my work
+Impact.attending_led_to,Submission of a grant application,submission of a grant application,Submission of a grant application
+Impact.attending_led_to,Submission of my dissertation/thesis for degree purposes,submission of my dissertation/thesis for degree purposes,Submission of my dissertation/ thesis for degree purposes
+Impact.attending_led_to,Useful collaboration(s) with other participants/trainers from the training event,useful collaboration(s) with other participants/trainers from the training event,Useful collaboration(s) with other participants/ trainers from the training event
+Impact.people_share_knowledge,None,none,None
+Impact.people_share_knowledge,"None yet, but intend to do so in the future","none yet, but intend to do so in the future","None yet, but intend to do so in the future"
+Impact.people_share_knowledge,1-5,1-5,1-5
+Impact.people_share_knowledge,6-15,6-15,6-15
+Impact.people_share_knowledge,16-24,16-24,16-24
+Impact.people_share_knowledge,25+,25+,25+
+Impact.recommend_others,"Yes, I already have","yes, i already have","Yes, I already have"
+Impact.recommend_others,"Yes, I would","yes, i would","Yes, I would"
+Impact.recommend_others,Maybe,maybe,Maybe
+Impact.recommend_others,No,no,No
+general.general,Non-ELIXIR / Non-EXCELERATE Funds,non-elixir/ non-excelerate funds,
+general.general,Training - e-learning,training - elearning,
+general.general,ELIXIR Converge,converge,
+general.general,EOSC Life,eosc-life,
+general.general,Knowledge Exchange Workshop,knowledge exchange workshop,
+general.general,ELIXIR Community / Use case,elixir community/ use case,
+general.general,To learn something new to aid me in my current research/work,to learn something new to aid me in my current research/ work,
+general.general,By using training materials/notes from the training event,by using training materials/ notes from the training event,
+general.general,To build on existing knowledge to aid me in my current research/work,to build an existing knowledge to aid me in my current research/ work,
+general.general,Useful collaboration(s) with other participants/trainers from the training event,useful collaboration(s) with other participants/ trainers from the training event,
+general.general,It improved communication with the bioinformatician/statistician analyzing my data,it improved communication with the bioinformatician/ statistician analyzing my data,
+general.general,It did not help as I do not use the tool(s)/resource(s) covered in the training event,it did not help as i do not use the tool(s)/ resource(s) covered in the training event,
+general.general,Submission of my dissertation/thesis for degree purposes,submission of my dissertation/ thesis for degree purposes,


### PR DESCRIPTION
This PR will address issue #42, it will:
- Add aliases for field values matching the original specification
- Add support for loading aliases from a csv file
- Adjust choices for `Event.target_audience` to be consistent with `Demographic.employment_sector`
- Make sure all affected fields use aliases
- Address some lint errors
- Add `make_alias_map` which will print an initial csv prepared to setup aliases

To test:
- check the csv `tmd/value-aliases-spec.csv` for errors
- upload test data using some values from the aliases (Preferably using values that follow the original spec)