### PR TITLE
BioHackathon 2024 - TeSS import proof-of-concept

### DIFF
--- a/app/metrics/templates/metrics/tess-import-form.html
+++ b/app/metrics/templates/metrics/tess-import-form.html
@@ -1,0 +1,37 @@
+{% extends "common/base.html" %}
+{% block content %}
+    <h1>{{title}}</h1>
+    {% include 'common/tabs.html' %}
+    {% include 'metrics/data-warning.html' %}
+    <div class="mb-3 row">
+        <div class="col-sm-8">
+            <h2>Event</h2>
+            {{form.errors}}
+            <form method="POST" enctype="multipart/form-data">
+                {% csrf_token %}
+                {% for field in form %}
+                    <div class="mb-3 row">
+                        <label for="{{field.html_name}}" class="col-sm-2 col-form-label">{{field.label}}</label>
+                        <div class="col-sm-10">
+                            {{field}}
+                        </div>
+                    </div>
+                {%endfor%}
+                <hr />
+                {% if form.fields and can_edit %}<button type="submit" class="btn btn-success">Import</button>{% endif %}
+            </form>
+        </div>
+        <div class="col-sm-4">
+            <h2>TeSS Metadata</h2>
+            <div class="tess-metadata">
+                {% if tess_url %}
+                    <a href="{{ tess_url }}" target="_blank">Go to TeSS entry</a><br/>
+                {% endif %}
+                {% for key, value in tess_metadata.items %}
+                    <strong>{{ key }}:</strong><br/>
+                    <span>{{ value }}</span><br/><br/>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/metrics/templates/metrics/tess-import.html
+++ b/app/metrics/templates/metrics/tess-import.html
@@ -1,0 +1,44 @@
+{% extends "common/base.html" %}
+{% block content %}
+    <h1>{{ title }}</h1>
+    {% include 'common/tabs.html' %}
+    {% include 'metrics/data-warning.html' %}
+    <link rel="stylesheet" property="stylesheet" href="https://elixirtess.github.io/TeSS_widgets/css/tess-widget.css"/>
+    <div id="tess-event-list" class="tess-widget"></div>
+    <script>
+    function initTeSSWidgets() {
+        const urlBase = "{% url 'tess-import' %}"
+        class TMDEventImportRenderer {
+            constructor (widget, element, options) {
+                this.widget = widget;
+                this.element = element;
+            }
+
+            initialize () {
+                const title = document.createElement('h1');
+                title.innerText = "TeSS Events:"
+                this.element.appendChild(title);
+                this.list = document.createElement('ul');
+                this.element.appendChild(this.list);
+            }
+
+            render (errors, data, response) {
+                this.list.innerHTML = ''; // Clear out old events.
+                data.data.forEach((event) => {
+                    const eventElement = document.createElement('li');
+                    eventElement.appendChild(document.createTextNode(event.attributes['title']));
+                    const importButton = document.createElement('a');
+                    importButton.className = 'btn btn-default';
+                    importButton.href = urlBase + '/' + event.id;
+                    importButton.appendChild(document.createTextNode('Import'));
+                    eventElement.appendChild(importButton);
+                    this.list.appendChild(eventElement);
+                });
+            }
+        }
+
+        TessWidget.Events(document.getElementById('tess-event-list'), TMDEventImportRenderer, {});
+    }
+    </script>
+    <script async="" defer="" src="https://elixirtess.github.io/TeSS_widgets/js/tess-widget-standalone.js" onload="initTeSSWidgets()"></script>
+{% endblock %}

--- a/app/metrics/templates/metrics/tess-import.html
+++ b/app/metrics/templates/metrics/tess-import.html
@@ -4,10 +4,59 @@
     {% include 'common/tabs.html' %}
     {% include 'metrics/data-warning.html' %}
     <link rel="stylesheet" property="stylesheet" href="https://elixirtess.github.io/TeSS_widgets/css/tess-widget.css"/>
-    <div id="tess-event-list" class="tess-widget"></div>
+    <div id="tess-container" class="tess-widget row">
+        <div id="tess-controls" class="col-sm-3">
+            <div class="form-group mb-2">
+                <label>Filter:</label>
+                <input id="tess-filter-q" class="form-control" type="text" placeholder="Keywords etc.">
+            </div>
+            <div class="form-group mb-2">
+                <label>From:</label>
+                <input id="tess-filter-from" class="form-control" type="date" placeholder="YYYY-MM-DD">
+            </div>
+            <div class="form-group mb-2">
+                <label>To:</label>
+                <input id="tess-filter-to" class="form-control" type="date" placeholder="YYYY-MM-DD">
+            </div>
+
+            <button id="tess-filter-confirm" class="btn btn-primary">Update</button>
+        </div>
+        <div id="tess-event-list-container" class="col-sm-9">
+            <div id="tess-event-list"></div>
+            <div id="tess-pagination" class="tess-pagination"></div>
+        </div>
+    </div>
     <script>
     function initTeSSWidgets() {
         const urlBase = "{% url 'tess-import' %}"
+
+        // Convenience function for making HTML elements
+        const n = function (type, htmlPropsOrFirstChild, ...children) {
+            const element = document.createElement(type);
+
+            if (htmlPropsOrFirstChild) {
+                if (htmlPropsOrFirstChild.constructor === Object) {
+                    if (htmlPropsOrFirstChild.data) {
+                        Object.entries(htmlPropsOrFirstChild.data).forEach(
+                            ([key, value]) => {
+                                element.setAttribute(('data-' + key), value)
+                            }
+                        );
+                    }
+
+                    Object.assign(element, htmlPropsOrFirstChild);
+                } else {
+                    children.unshift(htmlPropsOrFirstChild);
+                }
+            }
+
+            children.forEach((child) => {
+                element.appendChild((child instanceof Node) ? child : document.createTextNode(child));
+            });
+
+            return element;
+        }
+
         class TMDEventImportRenderer {
             constructor (widget, element, options) {
                 this.widget = widget;
@@ -15,29 +64,117 @@
             }
 
             initialize () {
-                const title = document.createElement('h1');
-                title.innerText = "TeSS Events:"
-                this.element.appendChild(title);
-                this.list = document.createElement('ul');
-                this.element.appendChild(this.list);
+                const widget = this.widget;
+                this.list = document.getElementById('tess-event-list');
+                this.pagination = document.getElementById('tess-pagination');
+                this.pagination.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    if (event.target.hasAttribute('data-tess-page')) {
+                        widget.setPage(event.target.getAttribute('data-tess-page'));
+                    }
+                });
+                this.query = document.getElementById('tess-filter-q');
+                this.dateFrom = document.getElementById('tess-filter-from');
+                this.dateTo = document.getElementById('tess-filter-to');
+                this.updateBtn = document.getElementById('tess-filter-confirm');
+                const renderer = this;
+                this.updateBtn.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    let dateFilter = '';
+                    if (renderer.checkDate(renderer.dateFrom)) {
+                        dateFilter += renderer.dateFrom.value + '/';
+                    }
+                    if (renderer.checkDate(renderer.dateTo)) {
+                        dateFilter += renderer.dateTo.value;
+                    }
+
+                    if (dateFilter) {
+                        // This currently doesn't work because of a missing line in TeSS' API spec
+                        widget.setFacet('start', dateFilter);
+                    } else {
+                        widget.clearFacet('start');
+                    }
+
+                    if (renderer.query.value) {
+                        widget.search(renderer.query.value);
+                    }
+
+                    return false;
+                });
             }
 
             render (errors, data, response) {
                 this.list.innerHTML = ''; // Clear out old events.
                 data.data.forEach((event) => {
-                    const eventElement = document.createElement('li');
-                    eventElement.appendChild(document.createTextNode(event.attributes['title']));
-                    const importButton = document.createElement('a');
-                    importButton.className = 'btn btn-default';
-                    importButton.href = urlBase + '/' + event.id;
-                    importButton.appendChild(document.createTextNode('Import'));
+                    const link = 'https://tess.elixir-europe.org' + event.links.self;
+                    const eventElement = n('div', { className: 'mb-3' })
+                    const importButton = n('a', { target: '_blank',
+                                                  className: 'btn btn-sm btn-success',
+                                                  style: 'float: right',
+                                                  href: urlBase + '/' + event.id }, 'Import');
                     eventElement.appendChild(importButton);
+                    eventElement.appendChild(n('a', { href: link, target: '_blank' }, event.attributes.title));
+                    eventElement.appendChild(n('br'));
+                    let info = this.formatDate(event.attributes.start);
+
+                    if (event.attributes.presence === 'online') {
+                        info += ' @ Online';
+                    } else {
+                        info += ' @ ' + [event.attributes.country, event.attributes.city].filter(n => n).join(', ');
+                    }
+                    eventElement.appendChild(document.createTextNode(info));
                     this.list.appendChild(eventElement);
                 });
+
+                // FIXME: Pagination is not working (JS API client does not recognize links)
+                this.pagination.innerHTML = ''; // Clear out old pagination.
+                if (data.links.first || data.links.prev || data.links.next || data.links.last)
+                    this.pagination.appendChild(document.createTextNode('Page: '));
+
+                if (data.links.first)
+                    this.pagination.appendChild(this.pageLink('First', data.links.first));
+                if (data.links.prev)
+                    this.pagination.appendChild(this.pageLink('Previous', data.links.prev));
+                if (data.links.next)
+                    this.pagination.appendChild(this.pageLink('Next', data.links.next));
+                if (data.links.last)
+                    this.pagination.appendChild(this.pageLink('Last', data.links.last));
+            }
+
+            pageLink (title, path) {
+                // Strip the actual page number out from the path
+                const page = (path.match(/page%5Bnumber%5D=([0-9]+)/) || path.match(/page_number=([0-9]+)/))[1];
+                return n('a', { href: '#', className: 'tess-pagination-link', data: { 'tess-page' : page } }, title);
+            }
+
+            formatDate (date, dateFormat) {
+                return new Date(date).toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' });
+            }
+
+            checkDate (element) {
+                if (element.value) {
+                    if (element.value.match(/\d{4}-\d{2}-\d{2}/)) {
+                        element.classList.remove('is-invalid');
+                        return true;
+                    } else {
+                        element.classList.add('is-invalid');
+                        return 'err';
+                    }
+                }
+                element.classList.remove('is-invalid');
+                return false;
             }
         }
 
-        TessWidget.Events(document.getElementById('tess-event-list'), TMDEventImportRenderer, {});
+        TessWidget.Events(document.getElementById('tess-event-list'), TMDEventImportRenderer, {
+            opts: { },
+            params: {
+                pageSize: 15,
+                includeExpired: true,
+                sort: 'early',
+                node: ['{{ node }}']
+            }
+        });
     }
     </script>
     <script async="" defer="" src="https://elixirtess.github.io/TeSS_widgets/js/tess-widget-standalone.js" onload="initTeSSWidgets()"></script>

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from metrics import views
 from metrics.forms import UserLoginForm
 from metrics.views.upload import upload_data, download_event_template, download_questionsuperset_template
+from metrics.views.tess_import import tess_import
 from metrics.views.model_views import (
     EventView,
     InstitutionView,
@@ -24,6 +25,8 @@ urlpatterns = [
     path('upload-data', upload_data, name='upload-data'),
     path('download-event-template/', download_event_template, name='download_event_template'),
     path('download-questionsuperset-template/<int:questionsuperset_id>/<str:type>', download_questionsuperset_template, name='download_questionsuperset_template'),
+    path('tess-import', tess_import, name='tess-import'),
+    path('tess-import/<int:tess_id>', tess_import, name='tess-import'),
     path('event/<int:pk>', EventView.as_view(), name='event-edit'),
     path('event/<int:event_id>/upload-data', upload_data, name='upload-data-event'),
     path('institution/<int:pk>', InstitutionView.as_view(), name='institution-edit'),

--- a/app/metrics/views/common.py
+++ b/app/metrics/views/common.py
@@ -20,6 +20,7 @@ def get_tabs(request, view_name=None):
     user_input = (
         [
             ("Upload data", "upload-data"),
+            ("Import from TeSS", "tess-import"),
             ("Browse events", "event-list"),
             ("All institutions", "institution-list")
         ]
@@ -85,7 +86,7 @@ def generate_pie(metrics, title, xaxis, yaxis):
                 "xanchor": "left",
                 "yanchor": "top",
                 "y": 0.5,
-                "x": 1.05  
+                "x": 1.05
             }
         )
     }

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -132,10 +132,8 @@ class TessImportEventView(LoginRequiredMixin, CreateView):
     # Figure out how to avoid duplicating this from EventView
     model = models.Event
     fields = [
-        "user",
         "title",
         "node",
-        "node_main",
         "date_start",
         "date_end",
         "duration",
@@ -181,6 +179,12 @@ class TessImportEventView(LoginRequiredMixin, CreateView):
 
     def can_edit(self):
         return True
+
+    def form_valid(self, form):
+        obj = form.save(commit = False)
+        obj.user = self.request.user
+        obj.node_main = self.request.user.get_node()
+        return super().form_valid(form)
 
     def get_form(self):
         tmd_metadata = {}

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -208,15 +208,21 @@ class TessImportEventView(LoginRequiredMixin, CreateView):
             raise ValidationError(f"Could not fetch TeSS entry for: {tess_id}, {tess_url}, {response.status_code}")
 
     def convert_tess_metadata(self, tess_metadata):
+        # Take just the date part from the full date/time string
+        def convert_date(date):
+            if date:
+                return date[:10]
+
         converted = {
             "title": tess_metadata["data"]["attributes"]["title"],
             "url": tess_metadata["data"]["attributes"]["url"],
-            "date_start": tess_metadata["data"]["attributes"]["start"],
-            "date_end": tess_metadata["data"]["attributes"]["end"],
+            "date_start": convert_date(tess_metadata["data"]["attributes"]["start"]),
+            "date_end": convert_date(tess_metadata["data"]["attributes"]["end"]),
             "location_city": tess_metadata["data"]["attributes"]["city"],
             "location_country": tess_metadata["data"]["attributes"]["country"],
             "duration": tess_metadata["data"]["attributes"]["duration"]
         }
+
         return converted
 
 

--- a/app/metrics/views/tess_import.py
+++ b/app/metrics/views/tess_import.py
@@ -1,0 +1,41 @@
+from django.shortcuts import render
+
+from metrics.management.commands.load_data import get_data_sources
+from metrics.models import Node
+from .common import get_tabs
+from django import forms
+from django.forms.widgets import FileInput, Select, CheckboxInput
+import re
+import csv
+import io
+from metrics import import_utils, models
+import traceback
+from django.core.exceptions import ValidationError
+from django.db import transaction
+import datetime
+from django.contrib.auth.decorators import login_required
+import requests
+
+from .model_views import EventView, TessImportEventView
+
+DATA_SOURCES = get_data_sources()
+NODE_COUNTRIES = {}
+with open(DATA_SOURCES[Node]) as csvfile:
+    reader = csv.DictReader(csvfile)
+    for row in reader:
+        NODE_COUNTRIES[row['name']] = row['country']
+
+@login_required
+def tess_import(request, tess_id=None):
+    if tess_id is not None:
+        return TessImportEventView.as_view(tess_id = tess_id)(request)
+    else:
+        return render(
+            request,
+            'metrics/tess-import.html',
+            context={
+                "title": "Import from TeSS",
+                **get_tabs(request),
+                "node": NODE_COUNTRIES.get(request.user.get_node().name)
+            }
+        )

--- a/raw-tmd-data/example-data/nodes.csv
+++ b/raw-tmd-data/example-data/nodes.csv
@@ -5,7 +5,7 @@ ELIXIR-CZ,Czech Republic
 ELIXIR-DE,Germany
 ELIXIR-DK,Denmark
 ELIXIR-EE,Estonia
-ELIXIR-EMBL-EBI,UK
+ELIXIR-EMBL-EBI,EMBL
 ELIXIR-ES,Spain
 ELIXIR-FI,Finland
 ELIXIR-FR,France
@@ -21,4 +21,4 @@ ELIXIR-NO,Norway
 ELIXIR-PT,Portugal
 ELIXIR-SE,Sweden
 ELIXIR-SI,Slovenia
-ELIXIR-UK,UK
+ELIXIR-UK,United Kingdom


### PR DESCRIPTION
- Adds new page "Import from TeSS".
- Uses a TeSS javascript widget to list TeSS events, with some basic filters & pagination.
- Attempts some basic metadata mapping from TeSS -> TMD and displays in a form (with TeSS metadata displayed alongside).

![image](https://github.com/user-attachments/assets/548d72bc-03b4-4044-b3ce-50f82c649133)

![image](https://github.com/user-attachments/assets/a0e1d46b-a810-450a-a033-03ee0d1cf429)

### Things that needs improving:
- Does not track or display if an event has already been imported.
- Filtering is very basic.
- `TessImportEventView` duplicates code from `EventView` (fields etc.).
- TeSS metadata conversion probably should not happen in the model view.
- TeSS metadata display is very basic (JSON).