### PR TITLE
Adding admin permissions for questions

### DIFF
--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -47,9 +47,9 @@ class ResponseSetAdmin(ModelAdmin):
         return super().save_model(request, obj, form, change)
 
 
+
 @admin.register(QuestionSet)
 class QuestionSetAdmin(ModelAdmin):
-    exclude = EDIT_TRACKING_FIELDS
     prepopulated_fields = {"slug": ["name"]}
 
     list_display = (
@@ -57,14 +57,33 @@ class QuestionSetAdmin(ModelAdmin):
         "user",
     )
 
+    def get_queryset(self, request):
+        if request.user.is_superuser:
+            qs = super().get_queryset(request)
+            return qs
+        qs = super().get_queryset(request)
+        # Filter QuestionSets based on the node of associated QuestionSuperSets
+        exclude = EDIT_TRACKING_FIELDS  # needs to be included if we want to be able to change user for a set
+        return qs.filter(
+            user = request.user  # also add admin user
+        ).distinct()
+
     def save_model(self, request, obj, form, change):
-        obj.user = request.user
+        if 'user' in form.cleaned_data:
+            obj.user = form.cleaned_data['user']
+        else:
+            obj.user = request.user
         return super().save_model(request, obj, form, change)
+
+    def get_fields(self, request, obj = None):
+        fields = super().get_fields(request, obj)
+        if not request.user.is_superuser:
+            fields = [field for field in fields if field not in EDIT_TRACKING_FIELDS]
+        return fields
 
 
 @admin.register(QuestionSuperSet)
 class QuestionSuperSetAdmin(ModelAdmin):
-    exclude = EDIT_TRACKING_FIELDS
     prepopulated_fields = {"slug": ["name"]}
 
     list_display = (
@@ -73,23 +92,54 @@ class QuestionSuperSetAdmin(ModelAdmin):
         "user",
     )
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        # Filter QuestionSuperSets based on the user's node or allow them to view shared supersets (node=None)
+        return qs.filter(
+            user = request.user
+        ).distinct()
+
     def save_model(self, request, obj, form, change):
-        obj.user = request.user
+        if 'user' in form.cleaned_data:
+            obj.user = form.cleaned_data['user']
+        else:
+            obj.user = request.user
         return super().save_model(request, obj, form, change)
+
+    def get_fields(self, request, obj = None):
+        fields = super().get_fields(request, obj)
+        if not request.user.is_superuser:
+            fields = [field for field in fields if field not in EDIT_TRACKING_FIELDS]
+        return fields
 
 
 class AnswerAdmin(admin.TabularInline):
     model = Answer
-    exclude = EDIT_TRACKING_FIELDS
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        # Filter QuestionSuperSets based on the user's node or allow them to view shared supersets (node=None)
+        return qs.filter(
+            user = request.user
+        ).distinct()
 
     def get_prepopulated_fields(self, request, obj=None):
         return {"slug": ["text"]}
+
+    def get_fields(self, request, obj = None):
+        fields = super().get_fields(request, obj)
+        if not request.user.is_superuser:
+            fields = [field for field in fields if field not in EDIT_TRACKING_FIELDS]
+        return fields
 
 
 @admin.register(Question)
 class QuestionAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ["text"]}
-    exclude = EDIT_TRACKING_FIELDS
     list_display = (
         "text",
         "user",
@@ -98,11 +148,29 @@ class QuestionAdmin(admin.ModelAdmin):
         AnswerAdmin,
     ]
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        # Filter Questions through QuestionSets linked to QuestionSuperSets that match the user's node
+        return qs.filter(
+            user = request.user
+        ).distinct()
+
     def save_model(self, request, obj, form, change):
-        obj.user = request.user
+        if 'user' in form.cleaned_data:
+            obj.user = form.cleaned_data['user']
+        else:
+            obj.user = request.user
         return super().save_model(request, obj, form, change)
     
     def save_formset(self, request, form, formset, change):
         for instance in formset.save(commit=False):
             instance.user = request.user
         return super().save_formset(request, form, formset, change)
+
+    def get_fields(self, request, obj = None):
+        fields = super().get_fields(request, obj)
+        if not request.user.is_superuser:
+            fields = [field for field in fields if field not in EDIT_TRACKING_FIELDS]
+        return fields

--- a/app/metrics/management/commands/set_node_user_permissions.py
+++ b/app/metrics/management/commands/set_node_user_permissions.py
@@ -1,0 +1,67 @@
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand, CommandError
+from metrics.models import Question, QuestionSet, QuestionSuperSet
+
+
+class Command(BaseCommand):
+    help = 'Assign permissions to NodeUserGroup'
+
+    def handle(self, *args, **options):
+        self.assign_group()
+
+    def assign_group(self):
+        # Current nodes in the system
+        node_users = ['be',
+                      'ch',
+                      'cz',
+                      'de',
+                      'dk',
+                      'ebi',
+                      'ee',
+                      'embl',
+                      'es',
+                      'fi',
+                      'fr',
+                      'gr',
+                      'hu',
+                      'hub',
+                      'ie',
+                      'il',
+                      'it',
+                      'lu',
+                      'nl',
+                      'no',
+                      'pt',
+                      'se',
+                      'si',
+                      'uk'
+                     ]
+
+
+        # Create a new group
+        node_user_group, created = Group.objects.get_or_create(name= 'NodeUserGroup')
+
+        # Define the permissions to add
+        permissions = [
+            'view_question', 'add_question', 'change_question', 'delete_question',
+            'view_questionset', 'add_questionset', 'change_questionset', 'delete_questionset',
+            'view_questionsuperset', 'add_questionsuperset', 'change_questionsuperset', 'delete_questionsuperset',
+            'view_answer', 'add_answer', 'change_answer', 'delete_answer'
+        ]
+
+        # Assign permissions to the group
+        for perm_name in permissions:
+            perm = Permission.objects.get(codename = perm_name)
+            node_user_group.permissions.add(perm)
+
+        # Save the group to apply changes
+        node_user_group.save()
+
+        # Add a user to this group
+        from django.contrib.auth.models import User
+        for node_user in node_users:
+            user = User.objects.get(username = node_user)
+            user.groups.add(node_user_group)
+            user.is_staff = True
+            user.save()


### PR DESCRIPTION
This PR is an initial attempt to set the correct admin levels also for node users, giving them permissions to access the Django admin panel, but with restricted access. See issue #67 for more details.

This PR does not fully solve issue #67, but is done to merge everything together in develop, making it possible to update the admin rights to also work with the new users that are connect to a node.