### PR TITLE
fix: disable metrics upload for locked events

### DIFF
--- a/app/metrics/import_utils.py
+++ b/app/metrics/import_utils.py
@@ -218,7 +218,7 @@ class LegacyImportContext(ImportContext):
         return self._timestamps
 
     def assert_can_change_data(self, user, event):
-        if user.get_node() != event.node_main:
+        if not event.is_locked and user.get_node() != event.node_main:
             raise PermissionDenied(
                 f"The metrics for the event {event.id}, {event.code} can not"
                 f" be updated by the current user: {user.username}"


### PR DESCRIPTION
This PR prevents upload of metrics to locked events.