### PR TITLE
fix: prevent server error when no items are available in a list view

### DIFF
--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -180,7 +180,11 @@ class GenericListView(ListView):
             self.get_entry_extras(entry)
             for entry in context["object_list"]
         ]
-        max_extras = max(len(e) for e in extras_list)
+        max_extras = (
+            max(len(e) for e in extras_list)
+            if len(extras_list) > 0
+            else 0
+        )
         context["table_headings"] = [
             *["" for _i in range(max_extras)],
             *[


### PR DESCRIPTION
This PR will prevent the server form giving a server error when a list view is empty.

To test:
- start a new instance of the system with no events or institutions
- go to: http://localhost:8000/institution/list
- go to: http://localhost:8000/event/list
- Make sure they don't return 500 server error