### PR TITLE
fix: show all metrics options including unused variants

### DIFF
--- a/app/metrics/middleware.py
+++ b/app/metrics/middleware.py
@@ -28,6 +28,10 @@ def get_model_field_options(model):
     )
 
 
+def get_list(value):
+    return value if isinstance(value, list) else [value]
+
+
 class EventGroup():
     def __init__(
         self,
@@ -91,11 +95,11 @@ class EventGroup():
         if params.get("type"):
             query = query.filter(type=params.get("type"))
         if params.get("funding"):
-            query = query.filter(funding=params.get("funding"))
+            query = query.filter(funding__contains=get_list(params.get("funding")))
         if params.get("target_audience"):
-            query = query.filter(target_audience=params.get("target_audience"))
+            query = query.filter(target_audience__contains=get_list(params.get("target_audience")))
         if params.get("additional_platforms"):
-            query = query.filter(additional_platforms=params.get("additional_platforms"))
+            query = query.filter(additional_platforms__contains=get_list(params.get("additional_platforms")))
 
         date_from = params.get("date_from")
         date_to = params.get("date_to")
@@ -201,11 +205,11 @@ class Group():
         if params.get("event_type"):
             query = query.filter(event__type=params.get("event_type"))
         if params.get("event_funding"):
-            query = query.filter(event__funding=params.get("event_funding"))
+            query = query.filter(event__funding__contains=get_list(params.get("event_funding")))
         if params.get("event_target_audience"):
-            query = query.filter(event__target_audience=params.get("event_target_audience"))
+            query = query.filter(event__target_audience__contains=get_list(params.get("event_target_audience")))
         if params.get("event_additional_platforms"):
-            query = query.filter(event__additional_platforms=params.get("event_additional_platforms"))
+            query = query.filter(event__additional_platforms__contains=get_list(params.get("event_additional_platforms")))
 
         date_from = params.get("date_from")
         date_to = params.get("date_to")

--- a/app/metrics/views/common.py
+++ b/app/metrics/views/common.py
@@ -102,9 +102,10 @@ def get_callback(group):
         outputs = []
         for field_id, chart_type in zip(group.get_fields(), chart_types):
             metrics = calculate_metrics(values, field_id)
+            field_options = group.get_field_options(field_id)
             metrics = {
-                group.get_field_option_name(field_id, option_id): count
-                for option_id, count in metrics.items()
+                group.get_field_option_name(field_id, option_id): metrics.get(option_id, 0)
+                for option_id in {*field_options, *metrics.keys()}
             }
             if chart_type == 'bar':
                 outputs.append(generate_bar(


### PR DESCRIPTION
This PR will fix the last unchecked point in: #65 

It will load the field options from the model fields and display them as 0 values in the output.

To test:
- Go to: http://localhost:8000/event, http://localhost:8000/quality, http://localhost:8000/demographic, http://localhost:8000/impact
- Try all the different filters
- All the options should be visible as long as there is at least one data point in the filtered result