### PR TITLE
Fix/add ror id href

### DIFF
--- a/app/metrics/templates/metrics/model-form.html
+++ b/app/metrics/templates/metrics/model-form.html
@@ -15,7 +15,7 @@
                 {% for name, value in stats %}
                 <tr>
                     <td>{{ name }}</td>
-                    <td>{{ value }}</td>
+                    <td>{% if value.1 %}<a href="{{ value.1 }}">{{ value.0 }}</a>{% else %}{{ value.0 }}{% endif %}</td>
                 </tr>{% endfor %}
             </tbody>
         </table>

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -248,6 +248,9 @@ class GenericListView(ListView):
         )
 
     def parse_value(self, value):
+        if value is None:
+            return None
+
         value_list = (
             list(value.all())
             if hasattr(value, "all")


### PR DESCRIPTION
This PR will close #61 

It will:
- Make the ROR ID a clickable link in list view and in object view
- Add a link from organizing institution to a filtered event view (filtering on organization)

To test:
- Make sure you have at least one institution with ROR ID in your system
- Go to: http://localhost:8000/institution/list
- Click the ROR ID link
- Go back:
- Click on `View`
- Click the number of Events
- Make sure the list is filtered correctly