### PR TITLE
feat: add possibility for super users to generate password reset links

### DIFF
--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -1,10 +1,50 @@
 from django.conf import settings
+from django import utils
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.urls import reverse
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
-
+from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
 from metrics.models import Event
+from django.utils.html import format_html
 
 
 @admin.register(Event)
 class EventAdmin(ModelAdmin):
     pass
+
+
+class CustomUserAdmin(UserAdmin):
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_superuser:
+            return ('password_reset_link',)
+        return ()
+    
+    def get_fieldsets(self, request, obj=None):
+        if request.user.is_superuser:
+            return UserAdmin.fieldsets + (
+                ('Account Management', {'fields': ('password_reset_link',)}),
+            )
+        return UserAdmin.fieldsets
+
+    def get_reset_url(self, obj):
+        if obj:
+            base64_encoded_id = utils.http.urlsafe_base64_encode(utils.encoding.force_bytes(obj.id))
+            token = PasswordResetTokenGenerator().make_token(obj)
+            reset_url_args = {'uidb64': base64_encoded_id, 'token': token}
+            reset_path = reverse('password_reset_confirm', kwargs=reset_url_args)
+            return reset_path
+
+
+    def password_reset_link(self, obj):
+        if obj:
+            url = self.get_reset_url(obj)
+            return format_html('<a href="{url}">Reset Password</a>', url=url)
+
+    password_reset_link.short_description = "Password Reset Link"
+
+
+
+admin.site.unregister(User)
+admin.site.register(User, CustomUserAdmin)

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.views import LoginView, LogoutView, FormView
 from django.urls import path
+from django.contrib.auth import views as auth_views
 
 from metrics import views
 from metrics.forms import UserLoginForm
@@ -39,4 +40,6 @@ urlpatterns = [
         QualityMetricsDeleteView.as_view(),
         name="quality-delete-metrics"
     ),
+    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path('reset_done/', auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),
 ]


### PR DESCRIPTION
This PR adds part of the django password reset flow without the need for email delivery.

It will:
- Add a password reset link in the admin interface for `superuser`
- Enable the standard password reset views