### PR TITLE
fix: clarify the TMD target audience in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 This is the new Training Metrics Database of the [ELIXIR Training Platform](https://elixir-europe.org/platforms/training).
 
-The Training Metrics Database was developed in an effort to streamline data collection, storage, and visualisation for the Quality and Impact Subtask of the ELIXIR Training Platform, which aims to:
+The Training Metrics Database was developed in an effort to streamline data collection, storage, and visualisation for the Quality and Impact Subtask of the ELIXIR Training Platform, which aims to collect information from training events offered by ELIXIR Nodes, ideally all captured in [TeSS](https://tess.elixir-europe.org/events):
 
-- Describe the **audience demographic** being reached by ELIXIR-badged training events,
-- Assess the **quality** of ELIXIR-badged training events directly after they have taken place,
-- Evaluate the longer term **impact** that ELIXIR-badged training events have had on the work of training participants.
+- Describe the **audience demographic**
+- Assess the **quality** directly after they have taken place,
+- Evaluate the longer term **impact** that these events have had on the work of training participants.
 
 In an effort to achieve the above aims, the subtask, in collaboration with the [ELIXIR Training Coordinators](https://elixir-europe.org/platforms/training/how-organised), has compiled a set of core metrics for measuring audience demographics and training quality, in the short term, and training impact, in the longer term. Both sets of metrics are collected via feedback survey. In some cases, the demographic information is collected via registration form. These metrics were developed out of those already collected by ELIXIR training providers as well as from discussions with stakeholders and external training providers.
 


### PR DESCRIPTION
This PR aims to clarify the potential confusion around what an `ELIXIR-badged training event` could be, since such a badge does not currently exist.