### PR TITLE
Feat/add stats for new model

### DIFF
--- a/app/metrics/models/common.py
+++ b/app/metrics/models/common.py
@@ -135,27 +135,6 @@ class Event(EditTracking):
             self.date_start,
             self.date_end
         )
-
-    @property
-    def stats(self):
-        return [
-            (name, related.count())
-            for name, related in [
-                ("Quality metrics", self.quality),
-                ("Impact metrics", self.impact),
-                ("Demographic metrics", self.demographic)
-            ]
-        ]
-
-    @property
-    def metrics_status(self):
-        count = sum([1 if v > 0 else 0 for _n, v in self.stats])
-        return {
-            0: "None",
-            1: "Partial",
-            2: "Partial",
-            3: "Full"
-        }[count]
     
     @property
     def is_locked(self):

--- a/app/metrics/models/system.py
+++ b/app/metrics/models/system.py
@@ -10,7 +10,7 @@ class SystemSettings:
         return QuestionSuperSet.objects.filter(use_for_metrics=True).all()
     
     def get_upload_sets(self):
-        return QuestionSuperSet.objects.filter(user_for_upload=True).all()
+        return QuestionSuperSet.objects.filter(use_for_upload=True).all()
     
     def has_flag(self, flag):
         return flag in self._flags

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -14,6 +14,7 @@ from metrics.views.model_views import (
     QualityMetricsDeleteView,
     DemographicMetricsDeleteView,
     ImpactMetricsDeleteView,
+    SuperSetMetricsDeleteView,
 )
 
 urlpatterns = [
@@ -43,6 +44,10 @@ urlpatterns = [
     path('event/delete-metrics/quality/<int:pk>',
         QualityMetricsDeleteView.as_view(),
         name="quality-delete-metrics"
+    ),
+    path('event/delete-metrics/superset/<int:pk>/<str:superset_slug>',
+        SuperSetMetricsDeleteView.as_view(),
+        name="superset-delete-responses"
     ),
     path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('reset_done/', auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),

--- a/app/metrics/views/upload.py
+++ b/app/metrics/views/upload.py
@@ -271,10 +271,9 @@ def legacy_upload(request, event):
 
 
 def response_upload(request, event):
+    settings = models.SystemSettings.get_settings()
     node = request.user.get_node()
-    question_supersets = QuestionSuperSet.objects.filter(
-        use_for_upload=True
-    )
+    question_supersets = settings.get_upload_sets()
     event_upload_form = None
     if event is None:
         upload_type = UPLOAD_TYPES["events"]

--- a/app/metrics/views/upload.py
+++ b/app/metrics/views/upload.py
@@ -114,7 +114,7 @@ def get_import_context(data_type, user, node_main, event):
             }
         )
     elif data_type == "demographic_quality_metrics":
-        (
+        return (
             import_utils.legacy_to_current_quality_or_demographic_dict,
             import_context.quality_or_demographic_from_dict,
             {"summary": summary_output}


### PR DESCRIPTION
This PR relates to #73 

It will:
- Add support for deleting uploaded metrics in the new question set model
- Add support for listing the metrics status using the new question set model
- Fix a bug which prevented uploading Demographic metrics using the old model

To test:
- use: `TMD_FEATURE_FLAGS="use_new_model_upload,use_new_model_stats"` in your `django.env`
- start development environment
- make sure you have atleast one superset with `use_for_upload`
- upload data
- check that the event metrics status looks correct after upload
- delete metrics from the event
- make sure that the event metrics status looks correct after deletion