### PR TITLE
fix: pin plotly dependency to avoid unexpected breakages

### DIFF
--- a/app/utils/requirements.txt
+++ b/app/utils/requirements.txt
@@ -1,4 +1,5 @@
 django==4.2.*
+plotly==5.24.1
 django-plotly-dash==2.2.*
 numpy==1.26.*
 pandas==2.0.3


### PR DESCRIPTION
This PR will pin the plotly dependency in order to avoid problems when rebuilding the containers.

To test:
- rebuild containers
- load data
- make sure that the world map works as expected