### PR TITLE
fix: add missing field to legacy metrics views 'help_work'

### DIFF
--- a/app/metrics/middleware.py
+++ b/app/metrics/middleware.py
@@ -282,6 +282,7 @@ def get_metrics(request):
                 "how_often_use_after",
                 "able_to_explain",
                 "able_use_now",
+                "help_work",
                 "attending_led_to",
                 "people_share_knowledge",
                 "recommend_others",


### PR DESCRIPTION
Adds missing metrics field for `Impact` metrics when using the old model.

To test:
- Start dev environment
- Verify that the question "How did the training event help with your work?" can be found on the page http://localhost:8000/report/impact